### PR TITLE
Make it compile and run tests with latest v0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: 0.11.0
+        zig-version: master
 
     - name: Build
       run: zig build
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: 0.11.0
+        zig-version: master
 
     - name: Lint
       run: zig fmt --check src/*.zig
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: 0.11.0
+        zig-version: master
 
     - name: Test
       run: zig build test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: 0.10.0
+        zig-version: 0.11.0
 
     - name: Build
       run: zig build
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: 0.10.0
+        zig-version: 0.11.0
 
     - name: Lint
       run: zig fmt --check src/*.zig
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Zig
       uses: korandoru/setup-zig@v1
       with:
-        zig-version: 0.10.0
+        zig-version: 0.11.0
 
     - name: Test
       run: zig build test

--- a/build.zig
+++ b/build.zig
@@ -1,13 +1,13 @@
+const std = @import("std");
+const FileSource = std.build.FileSource;
 const Builder = @import("std").build.Builder;
 
 pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const lib = b.addStaticLibrary("ssz.zig", "src/main.zig");
-    lib.setBuildMode(mode);
-    lib.install();
+    const optimize = b.standardOptimizeOption(.{});
+    const lib = b.addStaticLibrary(.{ .name = "ssz.zig", .root_source_file = FileSource{ .path = "src/main.zig" }, .optimize = optimize, .target = .{} });
+    b.installArtifact(lib);
 
-    var main_tests = b.addTest("src/tests.zig");
-    main_tests.setBuildMode(mode);
+    var main_tests = b.addTest(std.Build.TestOptions{ .root_source_file = FileSource{ .path = "src/tests.zig" }, .optimize = optimize });
 
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&main_tests.step);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -410,7 +410,7 @@ test "chunk count of a Vector[C, N]" {
 // used at comptime to generate a bitvector from a byte vector
 fn bytesToBits(comptime N: usize, src: [N]u8) [N * 8]bool {
     var bitvector: [N * 8]bool = undefined;
-    for (src) |byte, idx| {
+    for (src, 0..) |byte, idx| {
         var i = 0;
         while (i < 8) : (i += 1) {
             bitvector[i + idx * 8] = ((byte >> (7 - i)) & 1) == 1;


### PR DESCRIPTION
This PR makes the necessary changes such that the project compiles and run tests with [the latest "master" version suggested by Zig](https://ziglang.org/download/) (i.e: `0.11.0-dev.3132+465272921`).

A summary of changes:
- `build.zig`: there were API-breaking changes that are now fixed.
- ci: always make it point to the latest official `master`, to force us a bit to stay on top of the latest official version.
- `*.zig`: fix some breaking API changes (i.e: `@typeInfo(...)` for `Struct` renaming field, and `for` loops that want to capture index now require an explicit range definition).

All changes were mandatory to make the library compile and run.