### PR TITLE
add List[N] utility type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently supported types:
  * `null`
  * `Vector[N]`
  * **tagged** unions
+ * `List[N]`
 
 Ziglang has the limitation that it's not possible to determine which union field is active without tags.
 
@@ -38,6 +39,7 @@ Supported types:
  * `Vector[N]`
  * unions
  * optionals
+ * `List[N]`
 
 ## Merkelization (experimental)
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -243,7 +243,7 @@ pub fn serialize(comptime T: type, data: T, l: *ArrayList(u8)) !void {
 pub fn deserialize(comptime T: type, serialized: []const u8, out: *T, allocator: ?std.mem.Allocator) !void {
     // shortcut if the type implements its own decode method
     if (comptime std.meta.hasFn(T, "sszDecode")) {
-        return T.sszDecode(serialized, out);
+        return T.sszDecode(serialized, out, allocator);
     }
 
     const info = @typeInfo(T);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -18,7 +18,7 @@ const BYTES_PER_LENGTH_OFFSET = 4;
 // Determine the serialized size of an object so that
 // the code serializing of variable-size objects can
 // determine the offset to the next object.
-fn serializedSize(comptime T: type, data: T) !usize {
+pub fn serializedSize(comptime T: type, data: T) !usize {
     const info = @typeInfo(T);
     return switch (info) {
         .Int => @sizeOf(T),

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -2,6 +2,7 @@
 //! data structures with the SSZ method.
 
 const std = @import("std");
+pub const utils = @import("./utils.zig");
 const ArrayList = std.ArrayList;
 const builtin = std.builtin;
 const sha256 = std.crypto.hash.sha2.Sha256;
@@ -43,7 +44,7 @@ fn serializedSize(comptime T: type, data: T) !usize {
 }
 
 /// Returns true if an object is of fixed size
-fn isFixedSizeObject(comptime T: type) !bool {
+pub fn isFixedSizeObject(comptime T: type) !bool {
     const info = @typeInfo(T);
     switch (info) {
         .Bool, .Int, .Null => return true,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -677,7 +677,7 @@ test "(de)serialize List[N]" {
     var list = ArrayList(u8).init(std.testing.allocator);
     defer list.deinit();
     try serialize(ListValidatorIndex, attesting_indices, &list);
-    var attesting_indices_deser: ListValidatorIndex = undefined;
+    var attesting_indices_deser = try ListValidatorIndex.init(0);
     try deserialize(ListValidatorIndex, list.items, &attesting_indices_deser);
     try expect(attesting_indices.eql(&attesting_indices_deser));
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -681,3 +681,15 @@ test "(de)serialize List[N]" {
     try deserialize(ListValidatorIndex, list.items, &attesting_indices_deser, null);
     try expect(attesting_indices.eql(&attesting_indices_deser));
 }
+
+test "List[N].fromSlice of structs" {
+    const PastryList = utils.List(Pastry, 100);
+    var start: usize = 0;
+    var end: usize = pastries.len;
+    _ = .{ &start, &end };
+    const pastry_list = try PastryList.fromSlice(pastries[start..end]);
+    for (pastries, 0..) |pastry, i| {
+        try expect(std.mem.eql(u8, pastry_list.get(i).name, pastry.name));
+        try expect(pastry_list.get(i).weight == pastry.weight);
+    }
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -667,7 +667,7 @@ test "calculate the root hash of an union" {
     try expect(std.mem.eql(u8, out[0..], exp2[0..]));
 }
 
-test "(de)serialize List[N]" {
+test "(de)serialize List[N] of fixed-length objects" {
     const MAX_VALIDATORS_PER_COMMITTEE: usize = 2048;
     const ListValidatorIndex = utils.List(u64, MAX_VALIDATORS_PER_COMMITTEE);
     var attesting_indices = try ListValidatorIndex.init(0);
@@ -680,6 +680,26 @@ test "(de)serialize List[N]" {
     var attesting_indices_deser = try ListValidatorIndex.init(0);
     try deserialize(ListValidatorIndex, list.items, &attesting_indices_deser, null);
     try expect(attesting_indices.eql(&attesting_indices_deser));
+}
+
+test "(de)serialize List[N] of variable-length objects" {
+    const ListOfStrings = utils.List([]const u8, 16);
+    var string_list = try ListOfStrings.init(0);
+    for (0..10) |i| {
+        try string_list.append(try std.fmt.allocPrint(std.testing.allocator, "count={}", .{i}));
+    }
+    defer for (0..string_list.len()) |i| {
+        std.testing.allocator.free(string_list.get(i));
+    };
+    var list = ArrayList(u8).init(std.testing.allocator);
+    defer list.deinit();
+    try serialize(ListOfStrings, string_list, &list);
+    var string_list_deser = try ListOfStrings.init(0);
+    try deserialize(ListOfStrings, list.items, &string_list_deser, null);
+    try expect(string_list.len() == string_list_deser.len());
+    for (0..string_list.len()) |i| {
+        try expect(std.mem.eql(u8, string_list.get(i), string_list_deser.get(i)));
+    }
 }
 
 test "List[N].fromSlice of structs" {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -249,7 +249,7 @@ test "(de)serializes a type with a custom serialization method" {
             try list.appendSlice(self.buffer[0..self.len]);
         }
 
-        pub fn sszDecode(serialized: []const u8, out: *Self) !void {
+        pub fn sszDecode(serialized: []const u8, out: *Self, _: ?std.mem.Allocator) !void {
             if (serialized.len == 0) {
                 return error.IndexOutOfBounds;
             }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -678,6 +678,6 @@ test "(de)serialize List[N]" {
     defer list.deinit();
     try serialize(ListValidatorIndex, attesting_indices, &list);
     var attesting_indices_deser = try ListValidatorIndex.init(0);
-    try deserialize(ListValidatorIndex, list.items, &attesting_indices_deser);
+    try deserialize(ListValidatorIndex, list.items, &attesting_indices_deser, null);
     try expect(attesting_indices.eql(&attesting_indices_deser));
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -30,11 +30,11 @@ pub fn List(comptime T: type, comptime N: usize) type {
                     }
                 }
             } else if (try isFixedSizeObject(Self.Item)) {
-                var i: usize = 0;
-                const pitch = @sizeOf(Self.Item);
-                while (i < serialized.len) : (i += pitch) {
+                const pitch = try lib.serializedSize(Self.Item, undefined);
+                const n_items = serialized.len / pitch;
+                for (0..n_items) |i| {
                     var item: Self.Item = undefined;
-                    try deserialize(Self.Item, serialized[i .. i + pitch], &item, allocator);
+                    try deserialize(Self.Item, serialized[i * pitch .. (i + 1) * pitch], &item, allocator);
                     try out.append(item);
                 }
             } else {
@@ -55,8 +55,8 @@ pub fn List(comptime T: type, comptime N: usize) type {
             }
         }
 
-        pub fn init(len: usize) error{Overflow}!Self {
-            return .{ .inner = try std.BoundedArray(T, N).init(len) };
+        pub fn init(length: usize) error{Overflow}!Self {
+            return .{ .inner = try std.BoundedArray(T, N).init(length) };
         }
 
         pub fn eql(self: *const Self, other: *Self) bool {
@@ -81,6 +81,10 @@ pub fn List(comptime T: type, comptime N: usize) type {
 
         pub fn set(self: *Self, i: usize, item: T) void {
             self.inner.set(i, item);
+        }
+
+        pub fn len(self: *Self) usize {
+            return self.inner.len;
         }
     };
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,0 +1,138 @@
+const std = @import("std");
+const lib = @import("./lib.zig");
+const serialize = lib.serialize;
+const deserialize = lib.deserialize;
+const isFixedSizeObject = lib.isFixedSizeObject;
+const ArrayList = std.ArrayList;
+
+pub fn List(comptime T: type, comptime max_size: usize) type {
+    return struct {
+        const Self = @This();
+        const Len = std.math.IntFittingRange(0, max_size);
+        const Item = T;
+
+        len: Len,
+        buffer: [max_size]T = undefined,
+
+        pub fn sszEncode(self: *const Self, l: *ArrayList(u8)) !void {
+            // BitList[N]
+            if (Self.Item == bool) {
+                var byte: u8 = 0;
+                for (self.buffer, 0..) |bit, index| {
+                    if (bit) {
+                        byte |= @as(u8, 1) << @as(u3, @truncate(index));
+                    }
+
+                    if (index % 8 == 7) {
+                        try l.append(byte);
+                        byte = 0;
+                    }
+                }
+
+                // Write the last byte if the length
+                // is not byte-aligned
+                if (self.len % 8 != 0) {
+                    try l.append(byte);
+                }
+            } else // List[N]
+            if (try isFixedSizeObject(Self.Item)) {
+                var i: usize = 0;
+                while (i < self.len) : (i += 1) {
+                    try serialize(Self.Item, self.buffer[i], l);
+                }
+            } else {
+                var start = l.items.len;
+
+                // Reserve the space for the offset
+                const offset = [_]u8{ 0, 0, 0, 0 };
+                for (self.buffer) |_| {
+                    _ = try l.writer().write(offset[0..4]);
+                }
+
+                // Now serialize one item after the other
+                // and update the offset list with its location.
+                for (self.buffer) |item| {
+                    std.mem.writeInt(u32, l.items[start .. start + 4][0..4], @as(u32, @truncate(l.items.len)), std.builtin.Endian.little);
+                    _ = try serialize(Self.Item, item, l);
+                    start += 4;
+                }
+            }
+        }
+
+        pub fn sszDecode(serialized: []const u8, out: *Self) !void {
+            // BitList[N] or regular List[N]?
+            if (Self.Item == bool) {
+                for (serialized, 0..) |byte, bindex| {
+                    var i = @as(u8, 0);
+                    var b = byte;
+                    while (bindex * 8 + i < out.len and i < 8) : (i += 1) {
+                        out[bindex * 8 + i] = b & 1 == 1;
+                        b >>= 1;
+                    }
+                }
+            } else if (try isFixedSizeObject(Self.Item)) {
+                out.len = 0;
+                var i: usize = 0;
+                const pitch = @sizeOf(Self.Item);
+                while (i < serialized.len) : (i += pitch) {
+                    try deserialize(Self.Item, serialized[i .. i + pitch], &out.buffer[out.len]);
+                    out.len += 1;
+                }
+            } else {
+                // first variable index is also the size of the list
+                // of indices. Recast that list as a []const u32.
+                const size = std.mem.readInt(u32, serialized[0..4], std.builtin.Endian.little) / @sizeOf(u32);
+                const indices = std.mem.bytesAsSlice(u32, serialized[0 .. size * 4]);
+                var i = @as(usize, 0);
+                while (i < size) : (i += 1) {
+                    const end = if (i < size - 1) indices[i + 1] else serialized.len;
+                    const start = indices[i];
+                    if (start >= serialized.len or end > serialized.len) {
+                        return error.IndexOutOfBounds;
+                    }
+                    try deserialize(Self.Item, serialized[start..end], &out.buffer[i]);
+                }
+            }
+        }
+
+        pub fn init(len: usize) error{Overflow}!Self {
+            if (len > max_size) return error.Overflow;
+            return Self{ .len = @intCast(len) };
+        }
+
+        pub fn eql(self: *const Self, other: *Self) bool {
+            return (self.len == other.len) and std.mem.eql(Self.Item, self.buffer[0..self.len], other.buffer[0..self.len]);
+        }
+
+        pub fn append(self: *Self, item: Self.Item) error{Overflow}!void {
+            if (self.len == max_size) {
+                return error.Overflow;
+            }
+
+            self.buffer[self.len] = item;
+            self.len += 1;
+        }
+
+        pub fn slice(self: *Self) []T {
+            return self.buffer[0..self.len];
+        }
+
+        pub fn fromSlice(m: []const T) error{Overflow}!Self {
+            var list = try init(m.len);
+            @memcpy(list.slice(), m);
+            return list;
+        }
+
+        pub fn get(self: Self, i: usize) T {
+            return self.slice()[i];
+        }
+
+        pub fn set(self: *Self, i: usize, item: T) void {
+            self.slice()[i] = item;
+        }
+
+        pub fn fromBoundedArrayAligned(baa: anytype) error{Overflow}!Self {
+            return fromSlice(baa.slice());
+        }
+    };
+}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -18,7 +18,7 @@ pub fn List(comptime T: type, comptime N: usize) type {
             try serialize([]const Item, self.inner.slice(), l);
         }
 
-        pub fn sszDecode(serialized: []const u8, out: *Self) !void {
+        pub fn sszDecode(serialized: []const u8, out: *Self, allocator: ?std.mem.Allocator) !void {
             // BitList[N] or regular List[N]?
             if (Self.Item == bool) {
                 for (serialized, 0..) |byte, bindex| {
@@ -34,7 +34,7 @@ pub fn List(comptime T: type, comptime N: usize) type {
                 const pitch = @sizeOf(Self.Item);
                 while (i < serialized.len) : (i += pitch) {
                     var item: Self.Item = undefined;
-                    try deserialize(Self.Item, serialized[i .. i + pitch], &item, null);
+                    try deserialize(Self.Item, serialized[i .. i + pitch], &item, allocator);
                     try out.append(item);
                 }
             } else {
@@ -50,7 +50,7 @@ pub fn List(comptime T: type, comptime N: usize) type {
                         return error.IndexOutOfBounds;
                     }
                     const item = try out.inner.addOne();
-                    try deserialize(Self.Item, serialized[start..end], item, null);
+                    try deserialize(Self.Item, serialized[start..end], item, allocator);
                 }
             }
         }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -88,3 +88,7 @@ pub fn List(comptime T: type, comptime N: usize) type {
         }
     };
 }
+
+pub fn Bitlist(comptime N: usize) type {
+    return List(bool, N);
+}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -10,9 +10,9 @@ pub fn List(comptime T: type, comptime N: usize) type {
     return struct {
         const Self = @This();
         const Item = T;
-        const Inner = @TypeOf(Self.inner);
+        const Inner = std.BoundedArray(T, N);
 
-        inner: std.BoundedArray(T, N),
+        inner: Inner,
 
         pub fn sszEncode(self: *const Self, l: *ArrayList(u8)) !void {
             try serialize([]const Item, self.inner.slice(), l);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -34,7 +34,7 @@ pub fn List(comptime T: type, comptime N: usize) type {
                 const pitch = @sizeOf(Self.Item);
                 while (i < serialized.len) : (i += pitch) {
                     var item: Self.Item = undefined;
-                    try deserialize(Self.Item, serialized[i .. i + pitch], &item);
+                    try deserialize(Self.Item, serialized[i .. i + pitch], &item, null);
                     try out.append(item);
                 }
             } else {
@@ -50,7 +50,7 @@ pub fn List(comptime T: type, comptime N: usize) type {
                         return error.IndexOutOfBounds;
                     }
                     const item = try out.inner.addOne();
-                    try deserialize(Self.Item, serialized[start..end], item);
+                    try deserialize(Self.Item, serialized[start..end], item, null);
                 }
             }
         }


### PR DESCRIPTION
As described in #14, this adds a utility type to support `List[N; MAX]`.

This is obtained as such:

```zig
    const ListValidatorIndex = utils.List(u64, MAX_VALIDATORS_PER_COMMITTEE);
    var attesting_indices = try ListValidatorIndex.init(0);
```

This is inspired from [BoundedArray](https://ratfactor.com/zig/stdlib-browseable2/bounded_array.zig.html), but implements custom serialization and deserialization methods, that can not be implemented on a standard container.