### PR TITLE
add tweakable merkle tree and path

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,11 +24,17 @@ pub fn build(b: *Builder) void {
         .target = target,
     });
     const run_main_tests = b.addRunArtifact(main_tests);
+
     const tests_tests = b.addTest(.{
         .root_source_file = .{ .cwd_relative = "src/tests.zig" },
         .optimize = optimize,
         .target = target,
     });
+    const tweak_hash = b.dependency("tweak_hash", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("tweak_hash");
+    tests_tests.root_module.addImport("tweak_hash", tweak_hash);
     tests_tests.root_module.addImport("ssz.zig", mod);
     const run_tests_tests = b.addRunArtifact(tests_tests);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .version = "0.0.4",
     .dependencies = .{
         .tweak_hash = .{
-            .url = "../tweak-hash",
+            .url = "git+https://github.com/bhaskar1001101/tweak-hash#63611fd65d9db28a7ea342ff2fd61b1e201727fd",
             .hash = "tweak_hash-0.0.0-b5xZ7JkRAABSp1CPFJpayRnzIt2tnLjzjTPfveqLiUXu",
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,5 +2,11 @@
     .name = .ssz,
     .fingerprint = 0x1d34bd0ceb1dfc2d,
     .version = "0.0.4",
+    .dependencies = .{
+        .tweak_hash = .{
+            .url = "../tweak-hash",
+            .hash = "tweak_hash-0.0.0-b5xZ7JkRAABSp1CPFJpayRnzIt2tnLjzjTPfveqLiUXu",
+        },
+    },
     .paths = .{""},
 }


### PR DESCRIPTION
hash size is not fixed to 32 and depends on the tweakable hash. 

merkleizeWithTweak needs to return the entire merkle tree for the secret key. it allocates memory but might go against the design of the library? (mentioned in #17) 

it is also generic over TweakHash instead of hasher as the zig-poseidon api is very different. 

tests will have to be added in the hash-sigz lib as tweakable hash function is not available here directly.

