### PR TITLE
iterate fixed-size arrays by element, not byte step

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -451,9 +451,13 @@ pub fn deserialize(T: type, serialized: []const u8, out: *T, allocator: ?Allocat
             } else {
                 const U = info.array.child;
                 if (try isFixedSizeObject(U)) {
-                    var i: usize = 0;
+                    // Step by one element. The previous loop used `i`
+                    // simultaneously as element index (out[i], out.len)
+                    // and byte stride (i += pitch); for any element size
+                    // > 1 that skipped the interior elements, leaving
+                    // them undefined and breaking the roundtrip.
                     const pitch = try comptime serializedFixedSize(U);
-                    while (i < out.len) : (i += pitch) {
+                    for (0..out.len) |i| {
                         try deserialize(U, serialized[i * pitch .. (i + 1) * pitch], &out[i], allocator);
                     }
                 } else {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -451,11 +451,6 @@ pub fn deserialize(T: type, serialized: []const u8, out: *T, allocator: ?Allocat
             } else {
                 const U = info.array.child;
                 if (try isFixedSizeObject(U)) {
-                    // Step by one element. The previous loop used `i`
-                    // simultaneously as element index (out[i], out.len)
-                    // and byte stride (i += pitch); for any element size
-                    // > 1 that skipped the interior elements, leaving
-                    // them undefined and breaking the roundtrip.
                     const pitch = try comptime serializedFixedSize(U);
                     for (0..out.len) |i| {
                         try deserialize(U, serialized[i * pitch .. (i + 1) * pitch], &out[i], allocator);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2247,6 +2247,59 @@ test "deeply nested dynamic structures use relative offsets" {
     try expect(std.mem.eql(u8, try decoded_inner2.get(0), "ccc"));
 }
 
+// Regression: deserialize for fixed-size [N]T where @sizeOf(T) > 1 wrote
+// only out[0], out[pitch], out[2*pitch] ... because the loop variable was
+// used as both the element index (out[i], i < out.len) and the byte step
+// (i += pitch). For [N]u8 (pitch=1) this accidentally worked; for any
+// wider element the interior elements were never written.
+test "roundtrip: [3]u16 preserves middle element" {
+    const data: [3]u16 = .{ 100, 200, 65535 };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([3]u16, data, &list, std.testing.allocator);
+    try expect(list.items.len == 6);
+
+    var out: [3]u16 = .{ 0, 0, 0 };
+    try deserialize([3]u16, list.items, &out, null);
+    try expect(out[0] == 100);
+    try expect(out[1] == 200);
+    try expect(out[2] == 65535);
+}
+
+test "roundtrip: [4]u64 preserves all elements" {
+    const data: [4]u64 = .{ 0, 1, 0xdeadbeef, std.math.maxInt(u64) };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([4]u64, data, &list, std.testing.allocator);
+    try expect(list.items.len == 32);
+
+    var out: [4]u64 = .{ 0, 0, 0, 0 };
+    try deserialize([4]u64, list.items, &out, null);
+    try expect(out[0] == 0);
+    try expect(out[1] == 1);
+    try expect(out[2] == 0xdeadbeef);
+    try expect(out[3] == std.math.maxInt(u64));
+}
+
+test "roundtrip: [2][4]u32 (nested fixed array) preserves inner elements" {
+    const data: [2][4]u32 = .{
+        .{ 1, 2, 3, 4 },
+        .{ 5, 6, 7, 8 },
+    };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([2][4]u32, data, &list, std.testing.allocator);
+    try expect(list.items.len == 32);
+
+    var out: [2][4]u32 = undefined;
+    try deserialize([2][4]u32, list.items, &out, null);
+    try expect(std.mem.eql(u32, &out[0], &.{ 1, 2, 3, 4 }));
+    try expect(std.mem.eql(u32, &out[1], &.{ 5, 6, 7, 8 }));
+}
+
 test {
     _ = @import("beacon_tests.zig");
 }


### PR DESCRIPTION
## Bug

\`deserialize\` for \`.array\` with fixed-size child uses \`i\` simultaneously as the element index and as the byte stride:

\`\`\`zig
var i: usize = 0;
const pitch = try comptime serializedFixedSize(U);
while (i < out.len) : (i += pitch) {
    try deserialize(U, serialized[i * pitch .. (i + 1) * pitch], &out[i], allocator);
}
\`\`\`

\`i < out.len\` treats \`i\` as an element index; \`i += pitch\` treats it as a byte step. For \`[N]u8\` (\`pitch = 1\`) the two uses coincide, which is why every existing test passes. For any wider element the loop only writes every \`pitch\`-th slot — interior elements are left undefined and the roundtrip diverges.

Concrete cases hit while consuming this library from [zeam](https://github.com/blockblaz/zeam) against leanSpec's \`test_basic_types\` fixtures:

| type | pitch | writes | leaves undefined |
|---|---|---|---|
| \`[3]u16\` | 2 | \`out[0]\`, \`out[2]\` | \`out[1]\` |
| \`[4]u64\` | 8 | \`out[0]\` | \`out[1..4]\` |
| \`[2][4]u32\` | 16 | \`out[0]\` | \`out[1]\` |

Re-serializing then produces garbage for the unwritten slots and the roundtrip test diverges.

## Fix

Step by one element and keep \`i * pitch\` as the byte slice:

\`\`\`zig
const pitch = try comptime serializedFixedSize(U);
for (0..out.len) |i| {
    try deserialize(U, serialized[i * pitch .. (i + 1) * pitch], &out[i], allocator);
}
\`\`\`

## Why existing tests didn't catch this

The only array-deserialize test, \`deserializes a Vector[N]\`, uses \`[2]Pastry\` where \`Pastry\` contains a \`[]const u8\` — variable-size. That routes through the offset-based decode branch, not the fixed-size branch this fix lives in.

Added three regression tests covering the previously-untested shape:

- \`[3]u16\` — primitive fixed-size element > 1 byte
- \`[4]u64\` — widest primitive int
- \`[2][4]u32\` — nested fixed-size array

Before the fix all three fail (interior elements zero / undefined). After, all 139 tests pass.

## Test plan

- [x] \`zig build test --summary all\` — 139/139 pass (was 136/139 with new regression tests on unfixed HEAD).