### PR TITLE
add caching in hashTreeRoot

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -880,6 +880,26 @@ fn packBits(bits: []const bool, l: *ArrayList(u8), allocator: Allocator) ![]chun
 pub fn hashTreeRoot(Hasher: type, T: type, value: T, out: *[Hasher.digest_length]u8, allocator: Allocator) !void {
     // Check if type has its own hashTreeRoot method at compile time
     if (comptime std.meta.hasFn(T, "hashTreeRoot")) {
+        // value is a by-value copy; if hashTreeRoot lazily allocates a new cache
+        // on this copy, we must free it to prevent leaks. But if the original
+        // already had a cache (shallow-copied into value), we must not free it.
+        const has_optional_cache = comptime blk: {
+            if (!std.meta.hasFn(T, "deinitCache")) break :blk false;
+            if (!@hasField(T, "cache")) break :blk false;
+            break :blk @typeInfo(@FieldType(T, "cache")) == .optional;
+        };
+        if (has_optional_cache) {
+            const cache_before = value.cache;
+            var mutable = value;
+            errdefer if (cache_before == null and mutable.cache != null) {
+                mutable.deinitCache();
+            };
+            try mutable.hashTreeRoot(Hasher, out, allocator);
+            if (cache_before == null and mutable.cache != null) {
+                mutable.deinitCache();
+            }
+            return;
+        }
         return value.hashTreeRoot(Hasher, out, allocator);
     }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -10,7 +10,7 @@ const Allocator = std.mem.Allocator;
 const Sha256 = std.crypto.hash.sha2.Sha256;
 
 /// Number of bytes per chunk.
-const BYTES_PER_CHUNK = 32;
+pub const BYTES_PER_CHUNK = 32;
 
 pub fn serializedFixedSize(T: type) !usize {
     const info = @typeInfo(T);
@@ -417,17 +417,13 @@ pub fn deserialize(T: type, serialized: []const u8, out: *T, allocator: ?Allocat
     const enforce_min = !has_custom_decode or comptime std.meta.hasFn(T, "minInLength");
     const enforce_max = !has_custom_decode or comptime std.meta.hasFn(T, "maxInLength");
 
-    // Bounds check: ensure serialized length is within [minInLength, maxInLength]
-    const min_len: ?usize = if (enforce_min) blk: {
-        const m = minInLength(T) catch break :blk null;
-        break :blk m;
-    } else null;
+    // Bounds check: ensure serialized length is within [minInLength, maxInLength].
+    // The bounds depend only on T, so fold them to comptime constants; types
+    // with no static bound (e.g. a slice) resolve to null and skip the check.
+    const min_len: ?usize = comptime if (enforce_min) (minInLength(T) catch null) else null;
     if (min_len) |m| if (serialized.len < m) return error.PayloadTooSmall;
 
-    const max_len: ?usize = if (enforce_max) blk: {
-        const m = maxInLength(T) catch break :blk null;
-        break :blk m;
-    } else null;
+    const max_len: ?usize = comptime if (enforce_max) (maxInLength(T) catch null) else null;
     if (max_len) |m| if (serialized.len > m) return error.PayloadTooLarge;
 
     // shortcut if the type implements its own decode method
@@ -734,8 +730,8 @@ pub fn chunkCount(T: type) usize {
     }
 }
 
-const chunk = [BYTES_PER_CHUNK]u8;
-const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
+pub const chunk = [BYTES_PER_CHUNK]u8;
+pub const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
 
 pub fn pack(T: type, values: T, l: *ArrayList(u8), allocator: Allocator) ![]chunk {
     try serialize(T, values, l, allocator);
@@ -914,26 +910,6 @@ fn packBits(bits: []const bool, l: *ArrayList(u8), allocator: Allocator) ![]chun
 pub fn hashTreeRoot(Hasher: type, T: type, value: T, out: *[Hasher.digest_length]u8, allocator: Allocator) !void {
     // Check if type has its own hashTreeRoot method at compile time
     if (comptime std.meta.hasFn(T, "hashTreeRoot")) {
-        // value is a by-value copy; if hashTreeRoot lazily allocates a new cache
-        // on this copy, we must free it to prevent leaks. But if the original
-        // already had a cache (shallow-copied into value), we must not free it.
-        const has_optional_cache = comptime blk: {
-            if (!std.meta.hasFn(T, "deinitCache")) break :blk false;
-            if (!@hasField(T, "cache")) break :blk false;
-            break :blk @typeInfo(@FieldType(T, "cache")) == .optional;
-        };
-        if (has_optional_cache) {
-            const cache_before = value.cache;
-            var mutable = value;
-            errdefer if (cache_before == null and mutable.cache != null) {
-                mutable.deinitCache();
-            };
-            try mutable.hashTreeRoot(Hasher, out, allocator);
-            if (cache_before == null and mutable.cache != null) {
-                mutable.deinitCache();
-            }
-            return;
-        }
         return value.hashTreeRoot(Hasher, out, allocator);
     }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -418,8 +418,6 @@ pub fn deserialize(T: type, serialized: []const u8, out: *T, allocator: ?Allocat
     const enforce_max = !has_custom_decode or comptime std.meta.hasFn(T, "maxInLength");
 
     // Bounds check: ensure serialized length is within [minInLength, maxInLength].
-    // The bounds depend only on T, so fold them to comptime constants; types
-    // with no static bound (e.g. a slice) resolve to null and skip the check.
     const min_len: ?usize = comptime if (enforce_min) (minInLength(T) catch null) else null;
     if (min_len) |m| if (serialized.len < m) return error.PayloadTooSmall;
 

--- a/src/merkle_cache.zig
+++ b/src/merkle_cache.zig
@@ -1,0 +1,270 @@
+const std = @import("std");
+const zeros = @import("./zeros.zig");
+
+const BYTES_PER_CHUNK = 32;
+const chunk = [BYTES_PER_CHUNK]u8;
+const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
+
+/// A cached Merkle tree using a flat 1-indexed array representation.
+/// Node 1 is the root. Node i has children 2i and 2i+1.
+/// Leaves occupy indices [capacity .. 2*capacity).
+pub fn MerkleCache(comptime Hasher: type) type {
+    return struct {
+        const Self = @This();
+        const hashes_of_zero = zeros.buildHashesOfZero(Hasher, 32, 256);
+
+        /// Flat array of tree nodes, 1-indexed. Length = 2 * capacity.
+        /// Index 0 is unused. nodes[1] = root. nodes[capacity..2*capacity] = leaves.
+        nodes: []chunk,
+        /// Number of leaf slots (next power of 2 of the limit).
+        capacity: usize,
+        /// Dirty leaf range (0-based, relative to leaf start).
+        /// dirty_low > dirty_high means no dirty leaves.
+        dirty_low: usize,
+        dirty_high: usize,
+        /// Whether the full tree has been computed at least once.
+        initialized: bool,
+        /// Cached length for mixInLength detection.
+        cached_length: usize,
+        /// Final root after mixInLength.
+        cached_root: chunk,
+        /// Whether cached_root is valid.
+        root_valid: bool,
+
+        pub fn init(allocator: std.mem.Allocator, limit: usize) !Self {
+            const capacity = if (limit > 0) try std.math.ceilPowerOfTwo(usize, limit) else 1;
+            const nodes = try allocator.alloc([BYTES_PER_CHUNK]u8, 2 * capacity);
+            @memset(nodes, zero_chunk);
+            return .{
+                .nodes = nodes,
+                .capacity = capacity,
+                .dirty_low = 0,
+                .dirty_high = 0,
+                .initialized = false,
+                .cached_length = 0,
+                .cached_root = zero_chunk,
+                .root_valid = false,
+            };
+        }
+
+        pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
+            allocator.free(self.nodes);
+        }
+
+        pub fn markDirty(self: *Self, leaf_index: usize) void {
+            if (self.dirty_low > self.dirty_high) {
+                // Currently clean — set range to single leaf
+                self.dirty_low = leaf_index;
+                self.dirty_high = leaf_index;
+            } else {
+                if (leaf_index < self.dirty_low) self.dirty_low = leaf_index;
+                if (leaf_index > self.dirty_high) self.dirty_high = leaf_index;
+            }
+            self.root_valid = false;
+        }
+
+        pub fn markAllDirty(self: *Self) void {
+            self.dirty_low = 0;
+            self.dirty_high = self.capacity - 1;
+            self.root_valid = false;
+        }
+
+        /// Mark clean (dirty_low > dirty_high).
+        fn markClean(self: *Self) void {
+            self.dirty_low = 1;
+            self.dirty_high = 0;
+        }
+
+        /// Set a leaf chunk value and mark it dirty.
+        pub fn setLeaf(self: *Self, index: usize, value: chunk) void {
+            self.nodes[self.capacity + index] = value;
+            self.markDirty(index);
+        }
+
+        /// Recompute the Merkle root, only rehashing dirty paths.
+        /// `num_chunks` is the number of actual data chunks (rest are zero-padded).
+        /// Returns the data root (before mixInLength).
+        pub fn recompute(self: *Self, num_chunks: usize) chunk {
+            if (!self.initialized) {
+                // First time: set all leaves beyond data to zero, hash everything bottom-up
+                for (num_chunks..self.capacity) |i| {
+                    self.nodes[self.capacity + i] = zero_chunk;
+                }
+                // Hash all internal nodes bottom-up
+                var level_size = self.capacity;
+                while (level_size > 1) : (level_size /= 2) {
+                    const level_start = level_size; // start index of this level
+                    var i = level_start;
+                    while (i < level_start + level_size) : (i += 2) {
+                        self.hashPair(i / 2, i, i + 1);
+                    }
+                }
+                self.initialized = true;
+                self.markClean();
+                return self.nodes[1];
+            }
+
+            // If nothing is dirty, return cached root
+            if (self.dirty_low > self.dirty_high) {
+                return self.nodes[1];
+            }
+
+            // Incremental update: rehash only dirty paths
+            // Start at leaf level, process dirty range, then walk up
+            var lo = self.dirty_low + self.capacity;
+            var hi = self.dirty_high + self.capacity;
+
+            // Ensure parents of the dirty range are rehashed at each level
+            while (lo > 1) {
+                // Align to pairs: we need to hash the parent of each node in [lo, hi]
+                const pair_lo = lo - (lo % 2); // round down to even (left sibling)
+                const pair_hi = hi + 1 - (hi % 2); // round up to odd (right sibling)
+
+                var i = pair_lo;
+                while (i < pair_hi) : (i += 2) {
+                    self.hashPair(i / 2, i, i + 1);
+                }
+
+                // Move to parent level
+                lo = pair_lo / 2;
+                hi = pair_hi / 2;
+            }
+
+            self.markClean();
+            return self.nodes[1];
+        }
+
+        fn hashPair(self: *Self, parent: usize, left: usize, right: usize) void {
+            var hasher = Hasher.init(Hasher.Options{});
+            hasher.update(&self.nodes[left]);
+            hasher.update(&self.nodes[right]);
+            hasher.final(&self.nodes[parent]);
+        }
+
+        /// Convenience: compute root with mixInLength applied.
+        pub fn recomputeWithLength(self: *Self, num_chunks: usize, length: usize) chunk {
+            const data_root = self.recompute(num_chunks);
+
+            if (self.root_valid and self.cached_length == length) {
+                return self.cached_root;
+            }
+
+            // Apply mixInLength
+            var length_buf: chunk = zero_chunk;
+            std.mem.writeInt(u64, length_buf[0..8], @intCast(length), .little);
+
+            var hasher = Hasher.init(Hasher.Options{});
+            hasher.update(&data_root);
+            hasher.update(&length_buf);
+            hasher.final(&self.cached_root);
+            self.cached_length = length;
+            self.root_valid = true;
+            return self.cached_root;
+        }
+    };
+}
+
+// Tests
+const Sha256 = std.crypto.hash.sha2.Sha256;
+const lib = @import("./lib.zig");
+
+test "MerkleCache produces same root as merkleize for single chunk" {
+    const cache_type = MerkleCache(Sha256);
+    var cache = try cache_type.init(std.testing.allocator, 1);
+    defer cache.deinit(std.testing.allocator);
+
+    const data: chunk = [_]u8{0xAB} ** 32;
+    cache.setLeaf(0, data);
+
+    const cached_root = cache.recompute(1);
+
+    var expected: chunk = undefined;
+    var chunks = [_]chunk{data};
+    try lib.merkleize(Sha256, &chunks, 1, &expected);
+
+    try std.testing.expectEqualSlices(u8, &expected, &cached_root);
+}
+
+test "MerkleCache produces same root as merkleize for multiple chunks" {
+    const cache_type = MerkleCache(Sha256);
+    var cache = try cache_type.init(std.testing.allocator, 4);
+    defer cache.deinit(std.testing.allocator);
+
+    var chunks: [3]chunk = undefined;
+    for (0..3) |i| {
+        const byte: u8 = @intCast(i + 1);
+        chunks[i] = [_]u8{byte} ** 32;
+        cache.setLeaf(i, chunks[i]);
+    }
+
+    const cached_root = cache.recompute(3);
+
+    var expected: chunk = undefined;
+    try lib.merkleize(Sha256, &chunks, 4, &expected);
+
+    try std.testing.expectEqualSlices(u8, &expected, &cached_root);
+}
+
+test "MerkleCache incremental update matches full rebuild" {
+    const cache_type = MerkleCache(Sha256);
+    var cache = try cache_type.init(std.testing.allocator, 4);
+    defer cache.deinit(std.testing.allocator);
+
+    // Initial build with 4 chunks
+    var chunks: [4]chunk = undefined;
+    for (0..4) |i| {
+        const byte: u8 = @intCast(i + 1);
+        chunks[i] = [_]u8{byte} ** 32;
+        cache.setLeaf(i, chunks[i]);
+    }
+    _ = cache.recompute(4);
+
+    // Modify one chunk and recompute incrementally
+    chunks[2] = [_]u8{0xFF} ** 32;
+    cache.setLeaf(2, chunks[2]);
+    const incremental_root = cache.recompute(4);
+
+    // Full rebuild for comparison
+    var expected: chunk = undefined;
+    try lib.merkleize(Sha256, &chunks, 4, &expected);
+
+    try std.testing.expectEqualSlices(u8, &expected, &incremental_root);
+}
+
+test "MerkleCache recomputeWithLength matches merkleize + mixInLength" {
+    const cache_type = MerkleCache(Sha256);
+    var cache = try cache_type.init(std.testing.allocator, 8);
+    defer cache.deinit(std.testing.allocator);
+
+    var chunks: [3]chunk = undefined;
+    for (0..3) |i| {
+        const byte: u8 = @intCast(i + 10);
+        chunks[i] = [_]u8{byte} ** 32;
+        cache.setLeaf(i, chunks[i]);
+    }
+
+    const cached = cache.recomputeWithLength(3, 3);
+
+    // Compare: merkleize then mixInLength2
+    var data_root: chunk = undefined;
+    try lib.merkleize(Sha256, &chunks, 8, &data_root);
+    var expected: chunk = undefined;
+    lib.mixInLength2(Sha256, data_root, 3, &expected);
+
+    try std.testing.expectEqualSlices(u8, &expected, &cached);
+}
+
+test "MerkleCache empty chunks" {
+    const cache_type = MerkleCache(Sha256);
+    var cache = try cache_type.init(std.testing.allocator, 4);
+    defer cache.deinit(std.testing.allocator);
+
+    // No leaves set — all zeros
+    const cached_root = cache.recompute(0);
+
+    var expected: chunk = undefined;
+    const empty: []chunk = &.{};
+    try lib.merkleize(Sha256, empty, 4, &expected);
+
+    try std.testing.expectEqualSlices(u8, &expected, &cached_root);
+}

--- a/src/merkle_cache.zig
+++ b/src/merkle_cache.zig
@@ -1,46 +1,43 @@
 const std = @import("std");
+const lib = @import("./lib.zig");
 const zeros = @import("./zeros.zig");
 
-const BYTES_PER_CHUNK = 32;
-const chunk = [BYTES_PER_CHUNK]u8;
-const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
+const BYTES_PER_CHUNK = lib.BYTES_PER_CHUNK;
+const chunk = lib.chunk;
+const zero_chunk = lib.zero_chunk;
 
-/// A cached Merkle tree using a flat 1-indexed array representation.
-/// Node 1 is the root. Node i has children 2i and 2i+1.
-/// Leaves occupy indices [capacity .. 2*capacity).
+/// Depth at which a List/Bitlist of `chunk_limit` chunks must be merkleized,
+pub fn targetDepth(comptime chunk_limit: usize) usize {
+    if (chunk_limit <= 1) return 0;
+    return @bitSizeOf(usize) - @clz(chunk_limit - 1);
+}
+
+/// A grow-on-demand cached Merkle tree, generic over the hash function.
+///
+/// Flat 0-indexed binary tree: root at nodes[0], children of i at 2i+1/2i+2,
+/// leaves at nodes[capacity-1 .. 2*capacity-1].
 pub fn MerkleCache(comptime Hasher: type) type {
+    comptime std.debug.assert(Hasher.digest_length == BYTES_PER_CHUNK);
     return struct {
         const Self = @This();
-        const hashes_of_zero = zeros.buildHashesOfZero(Hasher, 32, 256);
+        /// Zero-subtree roots for this hasher. Index i is the root of an
+        /// all-zero subtree with 2^i leaves. Depth 64 covers any usize limit.
+        const hashes_of_zero = zeros.buildHashesOfZero(Hasher, BYTES_PER_CHUNK, 64);
 
-        /// Flat array of tree nodes, 1-indexed. Length = 2 * capacity.
-        /// Index 0 is unused. nodes[1] = root. nodes[capacity..2*capacity] = leaves.
         nodes: []chunk,
-        /// Number of leaf slots (next power of 2 of the limit).
         capacity: usize,
-        /// Dirty leaf range (0-based, relative to leaf start).
-        /// dirty_low > dirty_high means no dirty leaves.
-        dirty_low: usize,
-        dirty_high: usize,
-        /// Whether the full tree has been computed at least once.
-        initialized: bool,
-        /// Cached length for mixInLength detection.
+        dirty_low: ?usize,
+        dirty_high: ?usize,
         cached_length: usize,
-        /// Final root after mixInLength.
         cached_root: chunk,
-        /// Whether cached_root is valid.
         root_valid: bool,
 
-        pub fn init(allocator: std.mem.Allocator, limit: usize) !Self {
-            const capacity = if (limit > 0) try std.math.ceilPowerOfTwo(usize, limit) else 1;
-            const nodes = try allocator.alloc([BYTES_PER_CHUNK]u8, 2 * capacity);
-            @memset(nodes, zero_chunk);
+        pub fn init() Self {
             return .{
-                .nodes = nodes,
-                .capacity = capacity,
-                .dirty_low = 0,
-                .dirty_high = 0,
-                .initialized = false,
+                .nodes = &.{},
+                .capacity = 0,
+                .dirty_low = null,
+                .dirty_high = null,
                 .cached_length = 0,
                 .cached_root = zero_chunk,
                 .root_valid = false,
@@ -48,90 +45,72 @@ pub fn MerkleCache(comptime Hasher: type) type {
         }
 
         pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
-            allocator.free(self.nodes);
+            if (self.capacity > 0) allocator.free(self.nodes);
+            self.* = init();
+        }
+
+        /// Ensure the tree can hold `required_chunks` leaves. Growing reallocates
+        /// the node array, but the existing tree is exactly the leftmost subtree
+        /// of the larger one, so we transplant its already-computed nodes into
+        /// their shifted positions instead of rehashing them.
+        ///
+        /// Old level `d` (indices [2^d-1, 2^d-1+2^d)) maps to new level `d+k`
+        /// where `k = new_depth - old_depth`. Only the newly exposed leaf slots
+        /// [old_cap, new_cap) are marked dirty; the transplanted subtree is
+        /// reused, and the content-addressed refresh dirties any old leaf that
+        /// actually changed.
+        pub fn ensureCapacity(self: *Self, allocator: std.mem.Allocator, required_chunks: usize) !void {
+            if (required_chunks <= self.capacity) return;
+            const new_cap = try std.math.ceilPowerOfTwo(usize, required_chunks);
+            if (new_cap == self.capacity) return;
+            const new_nodes = try allocator.alloc(chunk, 2 * new_cap - 1);
+            @memset(new_nodes, zero_chunk);
+
+            const old_cap = self.capacity;
+            if (old_cap > 0) {
+                const old_depth = std.math.log2_int(usize, old_cap);
+                const new_depth = std.math.log2_int(usize, new_cap);
+                const k = new_depth - old_depth;
+                // Transplant the old tree level by level into the leftmost
+                // subtree of the new tree (no rehashing).
+                var d: usize = 0;
+                while (d <= old_depth) : (d += 1) {
+                    const count = @as(usize, 1) << @intCast(d);
+                    const old_start = count - 1; // 2^d - 1
+                    const new_start = (@as(usize, 1) << @intCast(d + k)) - 1; // 2^(d+k) - 1
+                    // The old tree is the leftmost subtree of the new one, so the
+                    // old leaves land at new indices [new_cap-1, new_cap-1+old_cap)
+                    // and every transplanted block stays within the new buffer.
+                    std.debug.assert(new_start + count <= new_nodes.len);
+                    @memcpy(new_nodes[new_start .. new_start + count], self.nodes[old_start .. old_start + count]);
+                }
+                allocator.free(self.nodes);
+            }
+
+            self.nodes = new_nodes;
+            self.capacity = new_cap;
+            // Reuse the transplanted left subtree; only the newly exposed leaf
+            // slots need recomputing (plus any old leaf the refresh re-dirties).
+            self.dirty_low = if (old_cap > 0) old_cap else 0;
+            self.dirty_high = new_cap - 1;
+            self.root_valid = false;
+        }
+
+        pub fn leafPtr(self: *Self, index: usize) *chunk {
+            std.debug.assert(index < self.capacity);
+            return &self.nodes[self.capacity - 1 + index];
         }
 
         pub fn markDirty(self: *Self, leaf_index: usize) void {
-            if (self.dirty_low > self.dirty_high) {
-                // Currently clean — set range to single leaf
+            std.debug.assert(leaf_index < self.capacity);
+            if (self.dirty_low) |low| {
+                self.dirty_low = @min(low, leaf_index);
+                self.dirty_high = @max(self.dirty_high.?, leaf_index);
+            } else {
                 self.dirty_low = leaf_index;
                 self.dirty_high = leaf_index;
-            } else {
-                if (leaf_index < self.dirty_low) self.dirty_low = leaf_index;
-                if (leaf_index > self.dirty_high) self.dirty_high = leaf_index;
             }
             self.root_valid = false;
-        }
-
-        pub fn markAllDirty(self: *Self) void {
-            self.dirty_low = 0;
-            self.dirty_high = self.capacity - 1;
-            self.root_valid = false;
-        }
-
-        /// Mark clean (dirty_low > dirty_high).
-        fn markClean(self: *Self) void {
-            self.dirty_low = 1;
-            self.dirty_high = 0;
-        }
-
-        /// Set a leaf chunk value and mark it dirty.
-        pub fn setLeaf(self: *Self, index: usize, value: chunk) void {
-            self.nodes[self.capacity + index] = value;
-            self.markDirty(index);
-        }
-
-        /// Recompute the Merkle root, only rehashing dirty paths.
-        /// `num_chunks` is the number of actual data chunks (rest are zero-padded).
-        /// Returns the data root (before mixInLength).
-        pub fn recompute(self: *Self, num_chunks: usize) chunk {
-            if (!self.initialized) {
-                // First time: set all leaves beyond data to zero, hash everything bottom-up
-                for (num_chunks..self.capacity) |i| {
-                    self.nodes[self.capacity + i] = zero_chunk;
-                }
-                // Hash all internal nodes bottom-up
-                var level_size = self.capacity;
-                while (level_size > 1) : (level_size /= 2) {
-                    const level_start = level_size; // start index of this level
-                    var i = level_start;
-                    while (i < level_start + level_size) : (i += 2) {
-                        self.hashPair(i / 2, i, i + 1);
-                    }
-                }
-                self.initialized = true;
-                self.markClean();
-                return self.nodes[1];
-            }
-
-            // If nothing is dirty, return cached root
-            if (self.dirty_low > self.dirty_high) {
-                return self.nodes[1];
-            }
-
-            // Incremental update: rehash only dirty paths
-            // Start at leaf level, process dirty range, then walk up
-            var lo = self.dirty_low + self.capacity;
-            var hi = self.dirty_high + self.capacity;
-
-            // Ensure parents of the dirty range are rehashed at each level
-            while (lo > 1) {
-                // Align to pairs: we need to hash the parent of each node in [lo, hi]
-                const pair_lo = lo - (lo % 2); // round down to even (left sibling)
-                const pair_hi = hi + 1 - (hi % 2); // round up to odd (right sibling)
-
-                var i = pair_lo;
-                while (i < pair_hi) : (i += 2) {
-                    self.hashPair(i / 2, i, i + 1);
-                }
-
-                // Move to parent level
-                lo = pair_lo / 2;
-                hi = pair_hi / 2;
-            }
-
-            self.markClean();
-            return self.nodes[1];
         }
 
         fn hashPair(self: *Self, parent: usize, left: usize, right: usize) void {
@@ -141,20 +120,66 @@ pub fn MerkleCache(comptime Hasher: type) type {
             hasher.final(&self.nodes[parent]);
         }
 
-        /// Convenience: compute root with mixInLength applied.
-        pub fn recomputeWithLength(self: *Self, num_chunks: usize, length: usize) chunk {
-            const data_root = self.recompute(num_chunks);
+        /// Root of the materialized data subtree (over `capacity` leaves, with
+        /// padding leaves already zero). Returns zero_chunk when empty. Only
+        /// rehashes the paths from dirty leaves up to the root.
+        pub fn recompute(self: *Self) chunk {
+            if (self.capacity == 0) return zero_chunk;
+            const low_leaf = self.dirty_low orelse return self.nodes[0];
+            var low = low_leaf + self.capacity - 1;
+            var high = self.dirty_high.? + self.capacity - 1;
 
+            while (low > 0) {
+                // Expand the range to whole sibling pairs. The pulled-in sibling
+                // is a clean (possibly transplanted) node, read as a valid input
+                // without being recomputed.
+                const pair_low = if (low % 2 == 1) low else low - 1;
+                const pair_high = if (high % 2 == 0) high else high + 1;
+
+                var i = pair_low;
+                while (i <= pair_high) : (i += 2) {
+                    self.hashPair((i - 1) / 2, i, i + 1);
+                }
+
+                low = (pair_low - 1) / 2;
+                high = (pair_high - 1) / 2;
+            }
+
+            self.dirty_low = null;
+            self.dirty_high = null;
+            return self.nodes[0];
+        }
+
+        /// Full SSZ root: extend the materialized data subtree with zero padding
+        /// up to `target_depth`, then mix in the length. Caches the result keyed
+        /// by `length`.
+        pub fn recomputeWithLength(self: *Self, length: usize, comptime target_depth: usize) chunk {
+            comptime std.debug.assert(target_depth <= 64);
+
+            // Hot path: nothing dirtied since the last identical-length root.
             if (self.root_valid and self.cached_length == length) {
                 return self.cached_root;
             }
 
-            // Apply mixInLength
+            const data_root = self.recompute();
+
+            // Climb from the materialized depth to the spec depth, hashing the
+            // running root against the all-zero subtree at each level.
+            const current_depth: usize = if (self.capacity > 0) std.math.log2_int(usize, self.capacity) else 0;
+            var current = data_root;
+            var level = current_depth;
+            while (level < target_depth) : (level += 1) {
+                var hasher = Hasher.init(Hasher.Options{});
+                hasher.update(&current);
+                hasher.update(&hashes_of_zero[level]);
+                hasher.final(&current);
+            }
+
             var length_buf: chunk = zero_chunk;
             std.mem.writeInt(u64, length_buf[0..8], @intCast(length), .little);
 
             var hasher = Hasher.init(Hasher.Options{});
-            hasher.update(&data_root);
+            hasher.update(&current);
             hasher.update(&length_buf);
             hasher.final(&self.cached_root);
             self.cached_length = length;
@@ -165,106 +190,169 @@ pub fn MerkleCache(comptime Hasher: type) type {
 }
 
 // Tests
-const Sha256 = std.crypto.hash.sha2.Sha256;
-const lib = @import("./lib.zig");
-
-test "MerkleCache produces same root as merkleize for single chunk" {
-    const cache_type = MerkleCache(Sha256);
-    var cache = try cache_type.init(std.testing.allocator, 1);
-    defer cache.deinit(std.testing.allocator);
-
-    const data: chunk = [_]u8{0xAB} ** 32;
-    cache.setLeaf(0, data);
-
-    const cached_root = cache.recompute(1);
-
-    var expected: chunk = undefined;
-    var chunks = [_]chunk{data};
-    try lib.merkleize(Sha256, &chunks, 1, &expected);
-
-    try std.testing.expectEqualSlices(u8, &expected, &cached_root);
+fn fillLeaves(comptime Hasher: type, cache: *MerkleCache(Hasher), chunks: []const chunk) void {
+    for (chunks, 0..) |c, i| {
+        cache.leafPtr(i).* = c;
+        cache.markDirty(i);
+    }
 }
 
-test "MerkleCache produces same root as merkleize for multiple chunks" {
-    const cache_type = MerkleCache(Sha256);
-    var cache = try cache_type.init(std.testing.allocator, 4);
+test "MerkleCache.recompute matches merkleize over its capacity" {
+    const Sha256 = std.crypto.hash.sha2.Sha256;
+    const Cache = MerkleCache(Sha256);
+
+    var cache = Cache.init();
     defer cache.deinit(std.testing.allocator);
 
     var chunks: [3]chunk = undefined;
-    for (0..3) |i| {
-        const byte: u8 = @intCast(i + 1);
-        chunks[i] = [_]u8{byte} ** 32;
-        cache.setLeaf(i, chunks[i]);
-    }
-
-    const cached_root = cache.recompute(3);
+    for (0..3) |i| chunks[i] = [_]u8{@intCast(i + 1)} ** 32;
+    try cache.ensureCapacity(std.testing.allocator, 3); // capacity -> 4
+    fillLeaves(Sha256, &cache, &chunks);
+    const root = cache.recompute();
 
     var expected: chunk = undefined;
-    try lib.merkleize(Sha256, &chunks, 4, &expected);
-
-    try std.testing.expectEqualSlices(u8, &expected, &cached_root);
+    try lib.merkleize(Sha256, &chunks, cache.capacity, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, &root);
 }
 
-test "MerkleCache incremental update matches full rebuild" {
-    const cache_type = MerkleCache(Sha256);
-    var cache = try cache_type.init(std.testing.allocator, 4);
-    defer cache.deinit(std.testing.allocator);
+test "MerkleCache.recomputeWithLength matches merkleize + mixInLength (limit 8)" {
+    const Sha256 = std.crypto.hash.sha2.Sha256;
 
-    // Initial build with 4 chunks
-    var chunks: [4]chunk = undefined;
-    for (0..4) |i| {
-        const byte: u8 = @intCast(i + 1);
-        chunks[i] = [_]u8{byte} ** 32;
-        cache.setLeaf(i, chunks[i]);
-    }
-    _ = cache.recompute(4);
-
-    // Modify one chunk and recompute incrementally
-    chunks[2] = [_]u8{0xFF} ** 32;
-    cache.setLeaf(2, chunks[2]);
-    const incremental_root = cache.recompute(4);
-
-    // Full rebuild for comparison
-    var expected: chunk = undefined;
-    try lib.merkleize(Sha256, &chunks, 4, &expected);
-
-    try std.testing.expectEqualSlices(u8, &expected, &incremental_root);
-}
-
-test "MerkleCache recomputeWithLength matches merkleize + mixInLength" {
-    const cache_type = MerkleCache(Sha256);
-    var cache = try cache_type.init(std.testing.allocator, 8);
+    var cache = MerkleCache(Sha256).init();
     defer cache.deinit(std.testing.allocator);
 
     var chunks: [3]chunk = undefined;
-    for (0..3) |i| {
-        const byte: u8 = @intCast(i + 10);
-        chunks[i] = [_]u8{byte} ** 32;
-        cache.setLeaf(i, chunks[i]);
-    }
+    for (0..3) |i| chunks[i] = [_]u8{@intCast(i + 10)} ** 32;
+    try cache.ensureCapacity(std.testing.allocator, 3);
+    fillLeaves(Sha256, &cache, &chunks);
 
-    const cached = cache.recomputeWithLength(3, 3);
+    const got = cache.recomputeWithLength(3, comptime targetDepth(8));
 
-    // Compare: merkleize then mixInLength2
     var data_root: chunk = undefined;
     try lib.merkleize(Sha256, &chunks, 8, &data_root);
     var expected: chunk = undefined;
     lib.mixInLength2(Sha256, data_root, 3, &expected);
-
-    try std.testing.expectEqualSlices(u8, &expected, &cached);
+    try std.testing.expectEqualSlices(u8, &expected, &got);
 }
 
-test "MerkleCache empty chunks" {
-    const cache_type = MerkleCache(Sha256);
-    var cache = try cache_type.init(std.testing.allocator, 4);
+test "MerkleCache empty list matches merkleize empty" {
+    const Sha256 = std.crypto.hash.sha2.Sha256;
+
+    var cache = MerkleCache(Sha256).init();
     defer cache.deinit(std.testing.allocator);
 
-    // No leaves set — all zeros
-    const cached_root = cache.recompute(0);
+    try std.testing.expect(cache.capacity == 0);
+    const got = cache.recomputeWithLength(0, comptime targetDepth(4));
+
+    var data_root: chunk = undefined;
+    const empty: []chunk = &.{};
+    try lib.merkleize(Sha256, empty, 4, &data_root);
+    var expected: chunk = undefined;
+    lib.mixInLength2(Sha256, data_root, 0, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, &got);
+}
+
+test "MerkleCache incremental update matches full rebuild" {
+    const Sha256 = std.crypto.hash.sha2.Sha256;
+    const Cache = MerkleCache(Sha256);
+
+    var cache = Cache.init();
+    defer cache.deinit(std.testing.allocator);
+
+    var chunks: [4]chunk = undefined;
+    for (0..4) |i| chunks[i] = [_]u8{@intCast(i + 1)} ** 32;
+    try cache.ensureCapacity(std.testing.allocator, 4);
+    fillLeaves(Sha256, &cache, &chunks);
+    _ = cache.recompute();
+
+    chunks[2] = [_]u8{0xFF} ** 32;
+    cache.leafPtr(2).* = chunks[2];
+    cache.markDirty(2);
+    const incremental = cache.recompute();
 
     var expected: chunk = undefined;
-    const empty: []chunk = &.{};
-    try lib.merkleize(Sha256, empty, 4, &expected);
+    try lib.merkleize(Sha256, &chunks, 4, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, &incremental);
+}
 
-    try std.testing.expectEqualSlices(u8, &expected, &cached_root);
+test "MerkleCache grow transplants and reuses the old subtree" {
+    const Sha256 = std.crypto.hash.sha2.Sha256;
+    const Cache = MerkleCache(Sha256);
+    var cache = Cache.init();
+    defer cache.deinit(std.testing.allocator);
+
+    const a: chunk = [_]u8{0xA1} ** 32;
+    const b: chunk = [_]u8{0xB2} ** 32;
+    try cache.ensureCapacity(std.testing.allocator, 2);
+    cache.leafPtr(0).* = a;
+    cache.markDirty(0);
+    cache.leafPtr(1).* = b;
+    cache.markDirty(1);
+    _ = cache.recompute();
+
+    // Grow to capacity 4. The old leaves must be transplanted, not zeroed, and
+    // we must NOT re-set them — only the new leaf gets written.
+    try cache.ensureCapacity(std.testing.allocator, 3);
+    try std.testing.expect(cache.capacity == 4);
+    try std.testing.expectEqualSlices(u8, &a, cache.leafPtr(0));
+    try std.testing.expectEqualSlices(u8, &b, cache.leafPtr(1));
+
+    const c: chunk = [_]u8{0xC3} ** 32;
+    cache.leafPtr(2).* = c;
+    cache.markDirty(2);
+    const root = cache.recompute();
+
+    var chunks = [_]chunk{ a, b, c, zero_chunk };
+    var expected: chunk = undefined;
+    try lib.merkleize(Sha256, &chunks, 4, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, &root);
+}
+
+test "MerkleCache multi-level grow reuses interior nodes (k>=2)" {
+    const Sha256 = std.crypto.hash.sha2.Sha256;
+    const Cache = MerkleCache(Sha256);
+    var cache = Cache.init();
+    defer cache.deinit(std.testing.allocator);
+
+    const a: chunk = [_]u8{0xA1} ** 32;
+    const b: chunk = [_]u8{0xB2} ** 32;
+    try cache.ensureCapacity(std.testing.allocator, 2);
+    cache.leafPtr(0).* = a;
+    cache.markDirty(0);
+    cache.leafPtr(1).* = b;
+    cache.markDirty(1);
+    _ = cache.recompute();
+
+    // Grow 2 -> 8 (k = 2). The old root H(a,b) becomes an *interior* node of the
+    // new tree (index 3) and must be reused without rehashing.
+    try cache.ensureCapacity(std.testing.allocator, 5);
+    try std.testing.expect(cache.capacity == 8);
+
+    // The transplanted interior node holds the old root H(a,b).
+    var old_root: chunk = undefined;
+    var ab = [_]chunk{ a, b };
+    try lib.merkleize(Sha256, &ab, 2, &old_root);
+    try std.testing.expectEqualSlices(u8, &old_root, &cache.nodes[3]);
+
+    // Add new data c,d,e without touching the reused leaves 0,1.
+    const c: chunk = [_]u8{0xC3} ** 32;
+    const d: chunk = [_]u8{0xD4} ** 32;
+    const e: chunk = [_]u8{0xE5} ** 32;
+    cache.leafPtr(2).* = c;
+    cache.markDirty(2);
+    cache.leafPtr(3).* = d;
+    cache.markDirty(3);
+    cache.leafPtr(4).* = e;
+    cache.markDirty(4);
+    const root = cache.recompute();
+
+    // Interior node still the reused old root; leaves 0,1 still a,b.
+    try std.testing.expectEqualSlices(u8, &old_root, &cache.nodes[3]);
+    try std.testing.expectEqualSlices(u8, &a, cache.leafPtr(0));
+    try std.testing.expectEqualSlices(u8, &b, cache.leafPtr(1));
+
+    var chunks = [_]chunk{ a, b, c, d, e, zero_chunk, zero_chunk, zero_chunk };
+    var expected: chunk = undefined;
+    try lib.merkleize(Sha256, &chunks, 8, &expected);
+    try std.testing.expectEqualSlices(u8, &expected, &root);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -2300,6 +2300,134 @@ test "roundtrip: [2][4]u32 (nested fixed array) preserves inner elements" {
     try expect(std.mem.eql(u32, &out[1], &.{ 5, 6, 7, 8 }));
 }
 
+test "Cached hashTreeRoot for List(u64) matches uncached" {
+    const ListU64 = utils.List(u64, 1024);
+    var list = try ListU64.init(std.testing.allocator);
+    defer list.deinit();
+
+    try list.append(1);
+    try list.append(2);
+    try list.append(3);
+
+    // Compute hash via lib.hashTreeRoot (value copy, cache cleaned up after)
+    var uncached: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListU64, list, &uncached, std.testing.allocator);
+
+    // Compute hash directly (cache persists on instance)
+    var cached: [32]u8 = undefined;
+    try list.hashTreeRoot(Sha256, &cached, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &cached, &uncached));
+
+    // Modify one element and verify cached recompute matches fresh uncached
+    try list.set(1, 42);
+
+    var cached2: [32]u8 = undefined;
+    try list.hashTreeRoot(Sha256, &cached2, std.testing.allocator);
+
+    // Build a fresh list with same data for comparison
+    var fresh = try ListU64.init(std.testing.allocator);
+    defer fresh.deinit();
+    try fresh.append(1);
+    try fresh.append(42);
+    try fresh.append(3);
+
+    var expected: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListU64, fresh, &expected, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &cached2, &expected));
+
+    // Verify it differs from original
+    try expect(!std.mem.eql(u8, &cached2, &uncached));
+}
+
+test "Cached hashTreeRoot for List with append" {
+    const ListU64 = utils.List(u64, 1024);
+    var list = try ListU64.init(std.testing.allocator);
+    defer list.deinit();
+
+    try list.append(10);
+
+    var hash1: [32]u8 = undefined;
+    try list.hashTreeRoot(Sha256, &hash1, std.testing.allocator);
+
+    // Append and recompute
+    try list.append(20);
+    var hash2: [32]u8 = undefined;
+    try list.hashTreeRoot(Sha256, &hash2, std.testing.allocator);
+
+    // Compare with fresh uncached
+    var fresh = try ListU64.init(std.testing.allocator);
+    defer fresh.deinit();
+    try fresh.append(10);
+    try fresh.append(20);
+
+    var expected: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListU64, fresh, &expected, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &hash2, &expected));
+    try expect(!std.mem.eql(u8, &hash1, &hash2));
+}
+
+test "Cached hashTreeRoot for composite List" {
+    const Point = struct { x: u32, y: u32 };
+    const ListOfPoint = utils.List(Point, 100);
+
+    var list = try ListOfPoint.init(std.testing.allocator);
+    defer list.deinit();
+
+    try list.append(.{ .x = 1, .y = 2 });
+    try list.append(.{ .x = 3, .y = 4 });
+
+    var cached: [32]u8 = undefined;
+    try list.hashTreeRoot(Sha256, &cached, std.testing.allocator);
+
+    var uncached: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListOfPoint, list, &uncached, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &cached, &uncached));
+}
+
+test "Cached hashTreeRoot for Bitlist matches uncached" {
+    const TestBitlist = utils.Bitlist(256);
+    var bl = try TestBitlist.init(std.testing.allocator);
+    defer bl.deinit();
+
+    try bl.append(true);
+    try bl.append(false);
+    try bl.append(true);
+    try bl.append(true);
+
+    // Uncached
+    var uncached: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, TestBitlist, bl, &uncached, std.testing.allocator);
+
+    var cached: [32]u8 = undefined;
+    try bl.hashTreeRoot(Sha256, &cached, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &cached, &uncached));
+
+    // Modify a bit and verify incremental update
+    try bl.set(1, true);
+    var cached2: [32]u8 = undefined;
+    try bl.hashTreeRoot(Sha256, &cached2, std.testing.allocator);
+
+    // Fresh comparison
+    var fresh = try TestBitlist.init(std.testing.allocator);
+    defer fresh.deinit();
+    try fresh.append(true);
+    try fresh.append(true);
+    try fresh.append(true);
+    try fresh.append(true);
+
+    var expected: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, TestBitlist, fresh, &expected, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &cached2, &expected));
+    try expect(!std.mem.eql(u8, &cached2, &uncached));
+}
+
 test {
     _ = @import("beacon_tests.zig");
+    _ = @import("merkle_cache.zig");
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1192,6 +1192,31 @@ test "minInLength/maxInLength for struct with List field" {
     try expect(try libssz.maxInLength(S) == 4 + 4 + 8 * 1);
 }
 
+test "minInLength/maxInLength fold at compile time" {
+    // The bounds depend only on the type, so they fold to compile-time
+    // constants usable directly in comptime contexts.
+    comptime {
+        std.debug.assert((libssz.maxInLength(u64) catch unreachable) == 8);
+        std.debug.assert((libssz.minInLength(u64) catch unreachable) == 8);
+        std.debug.assert((libssz.maxInLength([4]u8) catch unreachable) == 4);
+        std.debug.assert((libssz.minInLength(bool) catch unreachable) == 1);
+    }
+
+    const S = struct { a: u32, b: u16 };
+    // Used as an array length, proving the bound is a genuine compile-time constant.
+    const Buf = [libssz.maxInLength(S) catch unreachable]u8;
+    try expect(@typeInfo(Buf).array.len == 4 + 2);
+
+    const ListU64 = utils.List(u64, 16);
+    try expect(try libssz.maxInLength(ListU64) == 16 * 8);
+    try expect(try libssz.minInLength(ListU64) == 0);
+
+    // Dynamic/unbounded types still return a runtime error, not a compile error.
+    const VarS = struct { a: u32, b: []const u8 };
+    try expectError(error.NoMaxInLengthAvailable, libssz.maxInLength(VarS));
+    try expectError(error.NoMinInLengthAvailable, libssz.minInLength(VarS));
+}
+
 test "deserialize rejects payload longer than maxInLength" {
     var out_u32: u32 = undefined;
     try expectError(error.PayloadTooLarge, deserialize(u32, &[_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05 }, &out_u32, null));
@@ -2300,131 +2325,73 @@ test "roundtrip: [2][4]u32 (nested fixed array) preserves inner elements" {
     try expect(std.mem.eql(u32, &out[1], &.{ 5, 6, 7, 8 }));
 }
 
-test "Cached hashTreeRoot for List(u64) matches uncached" {
-    const ListU64 = utils.List(u64, 1024);
-    var list = try ListU64.init(std.testing.allocator);
-    defer list.deinit();
+test "TreeHasher(List(u64)) matches uncached and updates on set" {
+    const CachedList = utils.TreeHasher(utils.List(u64, 1024), Sha256);
+    var h = try CachedList.init(std.testing.allocator);
+    defer h.deinit();
 
-    try list.append(1);
-    try list.append(2);
-    try list.append(3);
+    try h.append(1);
+    try h.append(2);
+    try h.append(3);
 
-    // Compute hash via lib.hashTreeRoot (value copy, cache cleaned up after)
-    var uncached: [32]u8 = undefined;
-    try hashTreeRoot(Sha256, ListU64, list, &uncached, std.testing.allocator);
-
-    // Compute hash directly (cache persists on instance)
     var cached: [32]u8 = undefined;
-    try list.hashTreeRoot(Sha256, &cached, std.testing.allocator);
+    try h.hashTreeRoot(Sha256, &cached, std.testing.allocator);
 
+    // Truth: the uncached regular object.
+    var uncached: [32]u8 = undefined;
+    try h.inner.hashTreeRoot(Sha256, &uncached, std.testing.allocator);
     try expect(std.mem.eql(u8, &cached, &uncached));
 
-    // Modify one element and verify cached recompute matches fresh uncached
-    try list.set(1, 42);
-
+    // Modify one element; cached recompute must match a fresh uncached list.
+    try h.set(1, 42);
     var cached2: [32]u8 = undefined;
-    try list.hashTreeRoot(Sha256, &cached2, std.testing.allocator);
+    try h.hashTreeRoot(Sha256, &cached2, std.testing.allocator);
 
-    // Build a fresh list with same data for comparison
-    var fresh = try ListU64.init(std.testing.allocator);
+    var fresh = try utils.List(u64, 1024).init(std.testing.allocator);
     defer fresh.deinit();
     try fresh.append(1);
     try fresh.append(42);
     try fresh.append(3);
-
     var expected: [32]u8 = undefined;
-    try hashTreeRoot(Sha256, ListU64, fresh, &expected, std.testing.allocator);
-
-    try expect(std.mem.eql(u8, &cached2, &expected));
-
-    // Verify it differs from original
-    try expect(!std.mem.eql(u8, &cached2, &uncached));
-}
-
-test "Cached hashTreeRoot for List with append" {
-    const ListU64 = utils.List(u64, 1024);
-    var list = try ListU64.init(std.testing.allocator);
-    defer list.deinit();
-
-    try list.append(10);
-
-    var hash1: [32]u8 = undefined;
-    try list.hashTreeRoot(Sha256, &hash1, std.testing.allocator);
-
-    // Append and recompute
-    try list.append(20);
-    var hash2: [32]u8 = undefined;
-    try list.hashTreeRoot(Sha256, &hash2, std.testing.allocator);
-
-    // Compare with fresh uncached
-    var fresh = try ListU64.init(std.testing.allocator);
-    defer fresh.deinit();
-    try fresh.append(10);
-    try fresh.append(20);
-
-    var expected: [32]u8 = undefined;
-    try hashTreeRoot(Sha256, ListU64, fresh, &expected, std.testing.allocator);
-
-    try expect(std.mem.eql(u8, &hash2, &expected));
-    try expect(!std.mem.eql(u8, &hash1, &hash2));
-}
-
-test "Cached hashTreeRoot for composite List" {
-    const Point = struct { x: u32, y: u32 };
-    const ListOfPoint = utils.List(Point, 100);
-
-    var list = try ListOfPoint.init(std.testing.allocator);
-    defer list.deinit();
-
-    try list.append(.{ .x = 1, .y = 2 });
-    try list.append(.{ .x = 3, .y = 4 });
-
-    var cached: [32]u8 = undefined;
-    try list.hashTreeRoot(Sha256, &cached, std.testing.allocator);
-
-    var uncached: [32]u8 = undefined;
-    try hashTreeRoot(Sha256, ListOfPoint, list, &uncached, std.testing.allocator);
-
-    try expect(std.mem.eql(u8, &cached, &uncached));
-}
-
-test "Cached hashTreeRoot for Bitlist matches uncached" {
-    const TestBitlist = utils.Bitlist(256);
-    var bl = try TestBitlist.init(std.testing.allocator);
-    defer bl.deinit();
-
-    try bl.append(true);
-    try bl.append(false);
-    try bl.append(true);
-    try bl.append(true);
-
-    // Uncached
-    var uncached: [32]u8 = undefined;
-    try hashTreeRoot(Sha256, TestBitlist, bl, &uncached, std.testing.allocator);
-
-    var cached: [32]u8 = undefined;
-    try bl.hashTreeRoot(Sha256, &cached, std.testing.allocator);
-
-    try expect(std.mem.eql(u8, &cached, &uncached));
-
-    // Modify a bit and verify incremental update
-    try bl.set(1, true);
-    var cached2: [32]u8 = undefined;
-    try bl.hashTreeRoot(Sha256, &cached2, std.testing.allocator);
-
-    // Fresh comparison
-    var fresh = try TestBitlist.init(std.testing.allocator);
-    defer fresh.deinit();
-    try fresh.append(true);
-    try fresh.append(true);
-    try fresh.append(true);
-    try fresh.append(true);
-
-    var expected: [32]u8 = undefined;
-    try hashTreeRoot(Sha256, TestBitlist, fresh, &expected, std.testing.allocator);
+    try fresh.hashTreeRoot(Sha256, &expected, std.testing.allocator);
 
     try expect(std.mem.eql(u8, &cached2, &expected));
     try expect(!std.mem.eql(u8, &cached2, &uncached));
+}
+
+test "TreeHasher reflects direct backing-store mutation" {
+    // Content-addressed leaf refresh: mutating inner.items directly, bypassing
+    // set()/append(), must still produce a correct (non-stale) cached root.
+    const CachedList = utils.TreeHasher(utils.List(u64, 1024), Sha256);
+    var h = try CachedList.init(std.testing.allocator);
+    defer h.deinit();
+
+    try h.append(1);
+    try h.append(2);
+    try h.append(3);
+
+    var hash_before: [32]u8 = undefined;
+    try h.hashTreeRoot(Sha256, &hash_before, std.testing.allocator);
+
+    h.inner.inner.items[1] = 99; // direct mutation, no set()
+    var hash_after_first: [32]u8 = undefined;
+    try h.hashTreeRoot(Sha256, &hash_after_first, std.testing.allocator);
+
+    h.inner.inner.items[1] = 42;
+    var hash_after_second: [32]u8 = undefined;
+    try h.hashTreeRoot(Sha256, &hash_after_second, std.testing.allocator);
+
+    var fresh = try utils.List(u64, 1024).init(std.testing.allocator);
+    defer fresh.deinit();
+    try fresh.append(1);
+    try fresh.append(42);
+    try fresh.append(3);
+    var expected: [32]u8 = undefined;
+    try fresh.hashTreeRoot(Sha256, &expected, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &hash_after_second, &expected));
+    try expect(!std.mem.eql(u8, &hash_before, &hash_after_first));
+    try expect(!std.mem.eql(u8, &hash_after_first, &hash_after_second));
 }
 
 test "deserialize struct: invalid first var offset returns error (no slice panic)" {
@@ -2699,6 +2666,270 @@ test "utils.List dynamic-item: offsets decrease" {
     std.mem.writeInt(u32, buf[0..4], 8, .little);
     std.mem.writeInt(u32, buf[4..8], 4, .little);
     try expectError(error.OffsetOrdering, L.sszDecode(&buf, &out, std.testing.allocator));
+}
+
+test "TreeHasher(List(*Point)) reflects pointee mutation" {
+    const Point = struct { x: u32, y: u32 };
+    const CachedList = utils.TreeHasher(utils.List(*Point, 8), Sha256);
+
+    var h = try CachedList.init(std.testing.allocator);
+    defer h.deinit();
+
+    var p1: Point = .{ .x = 1, .y = 2 };
+    var p2: Point = .{ .x = 3, .y = 4 };
+    try h.append(&p1);
+    try h.append(&p2);
+
+    var hash_before: [32]u8 = undefined;
+    try h.hashTreeRoot(Sha256, &hash_before, std.testing.allocator);
+
+    p2.x = 999; // mutate pointee, bypassing set()
+    var hash_after: [32]u8 = undefined;
+    try h.hashTreeRoot(Sha256, &hash_after, std.testing.allocator);
+
+    var fresh_uncached: [32]u8 = undefined;
+    try h.inner.hashTreeRoot(Sha256, &fresh_uncached, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &hash_after, &fresh_uncached));
+    try expect(!std.mem.eql(u8, &hash_before, &hash_after));
+}
+
+test "TreeHasher zero-capacity List(u64,0) does not panic" {
+    const CachedList = utils.TreeHasher(utils.List(u64, 0), Sha256);
+    var h = try CachedList.init(std.testing.allocator);
+    defer h.deinit();
+
+    var cached: [32]u8 = undefined;
+    try h.hashTreeRoot(Sha256, &cached, std.testing.allocator);
+    var uncached: [32]u8 = undefined;
+    try h.inner.hashTreeRoot(Sha256, &uncached, std.testing.allocator);
+    try expect(std.mem.eql(u8, &cached, &uncached));
+}
+
+test "TreeHasher zero-capacity Bitlist(0) does not panic" {
+    const CachedBits = utils.TreeHasher(utils.Bitlist(0), Sha256);
+    var h = try CachedBits.init(std.testing.allocator);
+    defer h.deinit();
+
+    var cached: [32]u8 = undefined;
+    try h.hashTreeRoot(Sha256, &cached, std.testing.allocator);
+    var uncached: [32]u8 = undefined;
+    try h.inner.hashTreeRoot(Sha256, &uncached, std.testing.allocator);
+    try expect(std.mem.eql(u8, &cached, &uncached));
+}
+
+test "TreeHasher allocates proportional to data, not the SSZ limit" {
+    // A 2^40-element list must not try to allocate the full tree. Empty hashes
+    // instantly; adding a few items grows the cache by only a handful of nodes.
+    const Huge = utils.TreeHasher(utils.List(u32, 1 << 40), Sha256);
+    var h = try Huge.init(std.testing.allocator);
+    defer h.deinit();
+
+    var empty_cached: [32]u8 = undefined;
+    try h.hashTreeRoot(Sha256, &empty_cached, std.testing.allocator);
+    try expect(h.cache.capacity == 0); // zero allocation for empty
+    var empty_uncached: [32]u8 = undefined;
+    try h.inner.hashTreeRoot(Sha256, &empty_uncached, std.testing.allocator);
+    try expect(std.mem.eql(u8, &empty_cached, &empty_uncached));
+
+    // 10 u32 = 2 chunks -> capacity 2, i.e. 3 nodes, not 2^38 chunks.
+    for (0..10) |i| try h.append(@intCast(i));
+    var cached: [32]u8 = undefined;
+    try h.hashTreeRoot(Sha256, &cached, std.testing.allocator);
+    try expect(h.cache.capacity == 2);
+    var uncached: [32]u8 = undefined;
+    try h.inner.hashTreeRoot(Sha256, &uncached, std.testing.allocator);
+    try expect(std.mem.eql(u8, &cached, &uncached));
+}
+
+test "TreeHasher persists its cache when nested in a Container" {
+    const Container = struct {
+        balances: utils.TreeHasher(utils.List(u64, 1024), Sha256),
+    };
+
+    var c: Container = .{ .balances = try utils.TreeHasher(utils.List(u64, 1024), Sha256).init(std.testing.allocator) };
+    defer c.balances.deinit();
+
+    try c.balances.append(1);
+    try c.balances.append(2);
+
+    var h1: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, Container, c, &h1, std.testing.allocator);
+    // Cache persisted across the by-value container hash (not freed per call).
+    try expect(c.balances.cache.capacity > 0);
+
+    var h2: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, Container, c, &h2, std.testing.allocator);
+    try expect(std.mem.eql(u8, &h1, &h2));
+
+    try c.balances.set(0, 99);
+    var h3: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, Container, c, &h3, std.testing.allocator);
+    try expect(!std.mem.eql(u8, &h2, &h3));
+
+    // Final root matches a fresh uncached container.
+    var fresh = try utils.List(u64, 1024).init(std.testing.allocator);
+    defer fresh.deinit();
+    try fresh.append(99);
+    try fresh.append(2);
+    var expected_field: [32]u8 = undefined;
+    try fresh.hashTreeRoot(Sha256, &expected_field, std.testing.allocator);
+    var expected_container: [32]u8 = undefined;
+    // Container is a single-field struct: root = merkleize([field_root], null)
+    var chunks = [_][32]u8{expected_field};
+    try libssz.merkleize(Sha256, &chunks, null, &expected_container);
+    try expect(std.mem.eql(u8, &h3, &expected_container));
+}
+
+const SweepPoint = struct { x: u32, y: u32 };
+fn mkU8(i: usize) u8 {
+    return @truncate(i *% 7 +% 1);
+}
+fn mkU64(i: usize) u64 {
+    return @intCast((i *% 1000) +% 1);
+}
+fn mkU256(i: usize) u256 {
+    return (@as(u256, @intCast(i)) << 200) | @as(u256, @intCast(i));
+}
+fn mkPoint(i: usize) SweepPoint {
+    return .{ .x = @truncate(i), .y = @truncate(i *% 3) };
+}
+fn mkBool(i: usize) bool {
+    return i % 3 == 0;
+}
+
+fn sweepInner(comptime Inner: type, comptime makeItem: anytype) !void {
+    const alloc = std.testing.allocator;
+    const Cached = utils.TreeHasher(Inner, Sha256);
+    const counts = [_]usize{ 0, 1, 2, 3, 7, 8, 9, 16, 31, 32, 33 };
+    for (counts) |cnt| {
+        var h = try Cached.init(alloc);
+        defer h.deinit();
+        for (0..cnt) |i| try h.append(makeItem(i));
+
+        var c: [32]u8 = undefined;
+        try h.hashTreeRoot(Sha256, &c, alloc);
+        var u: [32]u8 = undefined;
+        try h.inner.hashTreeRoot(Sha256, &u, alloc);
+        try expect(std.mem.eql(u8, &c, &u));
+
+        if (cnt > 0) {
+            try h.set(0, makeItem(cnt + 3));
+            try h.hashTreeRoot(Sha256, &c, alloc);
+            try h.inner.hashTreeRoot(Sha256, &u, alloc);
+            try expect(std.mem.eql(u8, &c, &u));
+        }
+    }
+}
+
+test "TreeHasher parity sweep: List(u8)" {
+    try sweepInner(utils.List(u8, 256), mkU8);
+}
+test "TreeHasher parity sweep: List(u64)" {
+    try sweepInner(utils.List(u64, 1024), mkU64);
+}
+test "TreeHasher parity sweep: List(u256)" {
+    try sweepInner(utils.List(u256, 256), mkU256);
+}
+test "TreeHasher parity sweep: List(composite)" {
+    try sweepInner(utils.List(SweepPoint, 256), mkPoint);
+}
+test "TreeHasher parity sweep: Bitlist" {
+    try sweepInner(utils.Bitlist(2048), mkBool);
+}
+
+test "TreeHasher reflects backing-store shrink" {
+    const Cached = utils.TreeHasher(utils.List(u64, 64), Sha256);
+    var h = try Cached.init(std.testing.allocator);
+    defer h.deinit();
+    for (0..20) |i| try h.append(@intCast(i)); // 20 u64 = 5 chunks -> capacity 8
+    var c: [32]u8 = undefined;
+    try h.hashTreeRoot(Sha256, &c, std.testing.allocator);
+
+    // Shrink the backing store directly to 4 items (1 chunk), bypassing any API.
+    h.inner.inner.items.len = 4;
+    try h.hashTreeRoot(Sha256, &c, std.testing.allocator);
+    var u: [32]u8 = undefined;
+    try h.inner.hashTreeRoot(Sha256, &u, std.testing.allocator);
+    try expect(std.mem.eql(u8, &c, &u));
+}
+
+test "TreeHasher parity across many growth doublings" {
+    const Cached = utils.TreeHasher(utils.List(u256, 1 << 12), Sha256);
+    var h = try Cached.init(std.testing.allocator);
+    defer h.deinit();
+
+    var i: usize = 0;
+    while (i < 600) : (i += 1) {
+        try h.append(@intCast(i));
+        if (i % 7 == 0 or i + 1 == 600) {
+            var c: [32]u8 = undefined;
+            try h.hashTreeRoot(Sha256, &c, std.testing.allocator);
+            var u: [32]u8 = undefined;
+            try h.inner.hashTreeRoot(Sha256, &u, std.testing.allocator);
+            try expect(std.mem.eql(u8, &c, &u));
+
+            // Also mutate an earlier (reused-subtree) element and re-check.
+            if (i > 10) {
+                try h.set(i / 2, @intCast(i * 3));
+                try h.hashTreeRoot(Sha256, &c, std.testing.allocator);
+                try h.inner.hashTreeRoot(Sha256, &u, std.testing.allocator);
+                try expect(std.mem.eql(u8, &c, &u));
+            }
+        }
+    }
+}
+
+// Sha256 that counts finalize calls, to prove the cache reuses nodes on growth.
+var g_hash_calls: usize = 0;
+const CountingSha256 = struct {
+    inner: Sha256,
+    pub const digest_length = Sha256.digest_length;
+    pub const Options = Sha256.Options;
+    pub fn init(o: Options) @This() {
+        return .{ .inner = Sha256.init(o) };
+    }
+    pub fn update(self: *@This(), bytes: []const u8) void {
+        self.inner.update(bytes);
+    }
+    pub fn final(self: *@This(), out: *[digest_length]u8) void {
+        g_hash_calls += 1;
+        self.inner.final(out);
+    }
+    pub fn finalResult(self: *@This()) [digest_length]u8 {
+        // Used only at comptime (zero-hash table); must not touch runtime state.
+        return self.inner.finalResult();
+    }
+};
+
+test "TreeHasher reuses unchanged nodes when growing" {
+    const Cached = utils.TreeHasher(utils.List(u256, 1 << 14), CountingSha256);
+
+    // Build to capacity 512, then append one element to force a grow to 1024.
+    var grown = try Cached.init(std.testing.allocator);
+    defer grown.deinit();
+    for (0..512) |i| try grown.append(@intCast(i));
+    var out: [32]u8 = undefined;
+    try grown.hashTreeRoot(CountingSha256, &out, std.testing.allocator);
+
+    try grown.append(512);
+    g_hash_calls = 0;
+    try grown.hashTreeRoot(CountingSha256, &out, std.testing.allocator);
+    const grow_count = g_hash_calls;
+
+    // Build the same 513-chunk tree from scratch (full rebuild at capacity 1024).
+    var fresh = try Cached.init(std.testing.allocator);
+    defer fresh.deinit();
+    for (0..513) |i| try fresh.append(@intCast(i));
+    g_hash_calls = 0;
+    var out2: [32]u8 = undefined;
+    try fresh.hashTreeRoot(CountingSha256, &out2, std.testing.allocator);
+    const full_count = g_hash_calls;
+
+    // Same root, but the grow path reused the transplanted left subtree and so
+    // performed strictly fewer hashes than the from-scratch rebuild.
+    try expect(std.mem.eql(u8, &out, &out2));
+    try expect(grow_count < full_count);
 }
 
 test {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -8,6 +8,7 @@ const isFixedSizeObject = lib.isFixedSizeObject;
 const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
 const hashes_of_zero = @import("./zeros.zig").hashes_of_zero;
+const merkle_cache = @import("./merkle_cache.zig");
 
 // SSZ specification constants
 const BYTES_PER_CHUNK = 32;
@@ -30,6 +31,12 @@ pub fn List(T: type, comptime N: usize) type {
 
         inner: Inner,
         allocator: Allocator,
+        cache: ?*CacheType = null,
+
+        /// Hasher-agnostic cache type. We use SHA256 as the default since that's the
+        /// standard SSZ hasher, but the cache is only used when hashTreeRoot is called
+        /// with a matching hasher.
+        const CacheType = merkle_cache.MerkleCache(std.crypto.hash.sha2.Sha256);
 
         pub fn sszEncode(self: *const Self, l: *ArrayList(u8), allocator: Allocator) !void {
             try serialize([]const Item, self.constSlice(), l, allocator);
@@ -120,16 +127,18 @@ pub fn List(T: type, comptime N: usize) type {
         }
 
         pub fn deinit(self: *Self) void {
+            if (self.cache) |c| {
+                c.deinit(self.allocator);
+                self.allocator.destroy(c);
+                self.cache = null;
+            }
             self.inner.deinit(self.allocator);
         }
 
         pub fn append(self: *Self, item: Self.Item) error{ Overflow, OutOfMemory }!void {
             if (self.inner.items.len >= N) return error.Overflow;
-            return self.inner.append(self.allocator, item);
-        }
-
-        pub fn slice(self: *Self) []T {
-            return self.inner.items;
+            try self.inner.append(self.allocator, item);
+            self.invalidateCacheForIndex(self.inner.items.len - 1);
         }
 
         pub fn constSlice(self: *const Self) []const T {
@@ -151,6 +160,7 @@ pub fn List(T: type, comptime N: usize) type {
         pub fn set(self: *Self, i: usize, item: T) error{IndexOutOfBounds}!void {
             if (i >= self.inner.items.len) return error.IndexOutOfBounds;
             self.inner.items[i] = item;
+            self.invalidateCacheForIndex(i);
         }
 
         pub fn len(self: *const Self) usize {
@@ -163,6 +173,29 @@ pub fn List(T: type, comptime N: usize) type {
         }
 
         pub fn hashTreeRoot(self: *const Self, Hasher: type, out: *[32]u8, allocator: Allocator) !void {
+            if (Hasher == std.crypto.hash.sha2.Sha256) {
+                // Lazily initialize cache using self.allocator for consistent ownership
+                if (self.cache == null) {
+                    const limit = switch (@typeInfo(Item)) {
+                        .int => blk: {
+                            const bytes_per_item = @sizeOf(Item);
+                            const items_per_chunk = BYTES_PER_CHUNK / bytes_per_item;
+                            break :blk (N + items_per_chunk - 1) / items_per_chunk;
+                        },
+                        else => N,
+                    };
+                    const c = try self.allocator.create(CacheType);
+                    errdefer self.allocator.destroy(c);
+                    c.* = try CacheType.init(self.allocator, limit);
+                    @constCast(&self.cache).* = c;
+                }
+                return self.hashTreeRootCached(out, allocator);
+            }
+
+            return self.hashTreeRootUncached(Hasher, out, allocator);
+        }
+
+        fn hashTreeRootUncached(self: *const Self, Hasher: type, out: *[32]u8, allocator: Allocator) !void {
             const items = self.constSlice();
 
             switch (@typeInfo(Item)) {
@@ -186,11 +219,115 @@ pub fn List(T: type, comptime N: usize) type {
                         try lib.hashTreeRoot(Hasher, Item, item, &tmp, allocator);
                         try chunks.append(allocator, tmp);
                     }
-                    // Always use N (max capacity) for merkleization, even when empty
-                    // This ensures proper tree depth according to SSZ specification
                     try lib.merkleize(Hasher, chunks.items, N, &tmp);
                     lib.mixInLength2(Hasher, tmp, items.len, out);
                 },
+            }
+        }
+
+        /// Free the Merkle cache without freeing the list itself.
+        /// Called by lib.hashTreeRoot to clean up caches on value copies.
+        pub fn deinitCache(self: *Self) void {
+            if (self.cache) |c| {
+                c.deinit(self.allocator);
+                self.allocator.destroy(c);
+                self.cache = null;
+            }
+        }
+
+        fn hashTreeRootCached(self: *const Self, out: *[32]u8, allocator: Allocator) !void {
+            const Sha256 = std.crypto.hash.sha2.Sha256;
+            const items = self.constSlice();
+            const cache = self.cache.?;
+
+            switch (@typeInfo(Item)) {
+                .int => {
+                    // Pack items into chunks and update dirty leaves
+                    const bytes_per_item = @sizeOf(Item);
+                    const items_per_chunk = BYTES_PER_CHUNK / bytes_per_item;
+                    const chunks_for_max_capacity = (N + items_per_chunk - 1) / items_per_chunk;
+
+                    if (!cache.initialized) {
+                        // First time: set all leaf chunks
+                        for (0..items.len) |i| {
+                            const chunk_idx = i / items_per_chunk;
+                            const pos_in_chunk = (i % items_per_chunk) * bytes_per_item;
+                            var leaf = cache.nodes[cache.capacity + chunk_idx];
+                            // SSZ requires little-endian encoding
+                            std.mem.writeInt(Item, leaf[pos_in_chunk..][0..bytes_per_item], items[i], .little);
+                            cache.nodes[cache.capacity + chunk_idx] = leaf;
+                        }
+                        cache.markAllDirty();
+                    }
+                    // For dirty chunks, rebuild from current items
+                    if (cache.dirty_low <= cache.dirty_high) {
+                        const lo = cache.dirty_low;
+                        const hi = @min(cache.dirty_high, if (items.len > 0) (items.len - 1) / items_per_chunk else 0);
+                        for (lo..hi + 1) |chunk_idx| {
+                            var leaf: chunk = zero_chunk;
+                            const start_item = chunk_idx * items_per_chunk;
+                            const end_item = @min(start_item + items_per_chunk, items.len);
+                            for (start_item..end_item) |item_i| {
+                                const pos = (item_i % items_per_chunk) * bytes_per_item;
+                                // SSZ requires little-endian encoding
+                                std.mem.writeInt(Item, leaf[pos..][0..bytes_per_item], items[item_i], .little);
+                            }
+                            cache.nodes[cache.capacity + chunk_idx] = leaf;
+                        }
+                        // Zero out chunks beyond data
+                        for ((if (items.len > 0) (items.len - 1) / items_per_chunk + 1 else 0)..chunks_for_max_capacity) |chunk_idx| {
+                            if (chunk_idx >= cache.dirty_low and chunk_idx <= cache.dirty_high) {
+                                cache.nodes[cache.capacity + chunk_idx] = zero_chunk;
+                            }
+                        }
+                    }
+
+                    const num_data_chunks = if (items.len > 0) (items.len - 1) / items_per_chunk + 1 else 0;
+                    out.* = cache.recomputeWithLength(num_data_chunks, items.len);
+                },
+                else => {
+                    // Composite types: each item is its own chunk (hash tree root of item)
+                    // Composite items may contain pointers to mutable data that
+                    // can change without going through set(), so we must always
+                    // recompute all item hashes. We compare against cached leaves
+                    // to only mark actually-changed nodes dirty for tree rehashing.
+                    var tmp: chunk = undefined;
+                    for (items, 0..) |item, i| {
+                        try lib.hashTreeRoot(Sha256, Item, item, &tmp, allocator);
+                        if (!std.mem.eql(u8, &tmp, &cache.nodes[cache.capacity + i])) {
+                            cache.nodes[cache.capacity + i] = tmp;
+                            cache.markDirty(i);
+                        }
+                    }
+                    // Zero out any previously-occupied slots beyond current length
+                    if (cache.initialized) {
+                        for (items.len..cache.capacity) |i| {
+                            if (!std.mem.eql(u8, &zero_chunk, &cache.nodes[cache.capacity + i])) {
+                                cache.nodes[cache.capacity + i] = zero_chunk;
+                                cache.markDirty(i);
+                            }
+                        }
+                    } else {
+                        cache.markAllDirty();
+                    }
+
+                    out.* = cache.recomputeWithLength(items.len, items.len);
+                },
+            }
+        }
+
+        /// Compute the chunk index for a given element index and mark it dirty in the cache.
+        fn invalidateCacheForIndex(self: *Self, element_index: usize) void {
+            if (self.cache) |cache| {
+                const chunk_idx = switch (@typeInfo(Item)) {
+                    .int => blk: {
+                        const bytes_per_item = @sizeOf(Item);
+                        const items_per_chunk = BYTES_PER_CHUNK / bytes_per_item;
+                        break :blk element_index / items_per_chunk;
+                    },
+                    else => element_index,
+                };
+                cache.markDirty(chunk_idx);
             }
         }
 
@@ -228,6 +365,9 @@ pub fn Bitlist(comptime N: usize) type {
         inner: Inner,
         allocator: Allocator,
         length: usize,
+        cache: ?*BitCacheType = null,
+
+        const BitCacheType = merkle_cache.MerkleCache(std.crypto.hash.sha2.Sha256);
 
         pub fn sszEncode(self: *const Self, l: *ArrayList(u8), allocator: Allocator) !void {
             if (self.length == 0) {
@@ -315,6 +455,7 @@ pub fn Bitlist(comptime N: usize) type {
             const mask = ~@shlExact(@as(u8, 1), @truncate(i % 8));
             const b = if (bit) @shlExact(@as(u8, 1), @truncate(i % 8)) else 0;
             self.inner.items[i / 8] = @truncate((self.inner.items[i / 8] & mask) | b);
+            if (self.cache) |c| c.markDirty(i / 256);
         }
 
         pub fn append(self: *Self, item: bool) error{ Overflow, OutOfMemory, IndexOutOfBounds }!void {
@@ -331,6 +472,11 @@ pub fn Bitlist(comptime N: usize) type {
         }
 
         pub fn deinit(self: *Self) void {
+            if (self.cache) |c| {
+                c.deinit(self.allocator);
+                self.allocator.destroy(c);
+                self.cache = null;
+            }
             self.inner.deinit(self.allocator);
         }
 
@@ -344,34 +490,89 @@ pub fn Bitlist(comptime N: usize) type {
         }
 
         pub fn hashTreeRoot(self: *const Self, Hasher: type, out: *[32]u8, allocator: Allocator) !void {
+            if (Hasher == std.crypto.hash.sha2.Sha256) {
+                // Lazily initialize cache using self.allocator for consistent ownership
+                if (self.cache == null) {
+                    const chunk_count_limit = (N + 255) / 256;
+                    const c = try self.allocator.create(BitCacheType);
+                    errdefer self.allocator.destroy(c);
+                    c.* = try BitCacheType.init(self.allocator, chunk_count_limit);
+                    @constCast(&self.cache).* = c;
+                }
+                return self.hashTreeRootCached(out);
+            }
+            return self.hashTreeRootUncached(Hasher, out, allocator);
+        }
+
+        fn hashTreeRootUncached(self: *const Self, Hasher: type, out: *[32]u8, allocator: Allocator) !void {
             const bit_length = self.length;
 
             var bitfield_bytes: ArrayList(u8) = .empty;
             defer bitfield_bytes.deinit(allocator);
 
             if (bit_length > 0) {
-                // Get the internal bit data since we don't store delimiter
                 const sl = self.inner.items;
                 try bitfield_bytes.appendSlice(allocator, sl[0..sl.len]);
 
-                // Remove trailing zeros but keep at least one byte
-                // This avoids the wasteful pattern of removing all zeros then adding back a chunk
                 while (bitfield_bytes.items.len > 1 and bitfield_bytes.items[bitfield_bytes.items.len - 1] == 0) {
                     _ = bitfield_bytes.pop();
                 }
             }
 
-            // Pack bits into chunks (pad to chunk boundary)
             const padding_size = (BYTES_PER_CHUNK - bitfield_bytes.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
             _ = try bitfield_bytes.appendSlice(allocator, zero_chunk[0..padding_size]);
 
             const chunks = std.mem.bytesAsSlice(chunk, bitfield_bytes.items);
             var tmp: chunk = undefined;
 
-            // Use chunk_count limit as per SSZ specification
             const chunk_count_limit = (N + 255) / 256;
             try lib.merkleize(Hasher, chunks, chunk_count_limit, &tmp);
             lib.mixInLength2(Hasher, tmp, bit_length, out);
+        }
+
+        fn hashTreeRootCached(self: *const Self, out: *[32]u8) void {
+            const cache = self.cache.?;
+            const bit_length = self.length;
+
+            // Update dirty leaf chunks from current bit data
+            if (!cache.initialized) {
+                // Set all leaf chunks from bit data
+                const sl = self.inner.items;
+                const num_data_chunks = if (sl.len > 0) (sl.len - 1) / BYTES_PER_CHUNK + 1 else 0;
+                for (0..num_data_chunks) |ci| {
+                    var leaf: chunk = zero_chunk;
+                    const start = ci * BYTES_PER_CHUNK;
+                    const end = @min(start + BYTES_PER_CHUNK, sl.len);
+                    @memcpy(leaf[0 .. end - start], sl[start..end]);
+                    cache.nodes[cache.capacity + ci] = leaf;
+                }
+                cache.markAllDirty();
+            } else if (cache.dirty_low <= cache.dirty_high) {
+                const sl = self.inner.items;
+                const hi = @min(cache.dirty_high, if (sl.len > 0) (sl.len - 1) / BYTES_PER_CHUNK else 0);
+                for (cache.dirty_low..hi + 1) |ci| {
+                    var leaf: chunk = zero_chunk;
+                    const start = ci * BYTES_PER_CHUNK;
+                    const end = @min(start + BYTES_PER_CHUNK, sl.len);
+                    if (start < sl.len) {
+                        @memcpy(leaf[0 .. end - start], sl[start..end]);
+                    }
+                    cache.nodes[cache.capacity + ci] = leaf;
+                }
+            }
+
+            const num_data_chunks = if (self.inner.items.len > 0) (self.inner.items.len - 1) / BYTES_PER_CHUNK + 1 else 0;
+            out.* = cache.recomputeWithLength(num_data_chunks, bit_length);
+        }
+
+        /// Free the Merkle cache without freeing the bitlist itself.
+        /// Called by lib.hashTreeRoot to clean up caches on value copies.
+        pub fn deinitCache(self: *Self) void {
+            if (self.cache) |c| {
+                c.deinit(self.allocator);
+                self.allocator.destroy(c);
+                self.cache = null;
+            }
         }
 
         /// Validates that the bitlist is correctly formed

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -7,13 +7,11 @@ const deserialize = lib.deserialize;
 const isFixedSizeObject = lib.isFixedSizeObject;
 const ArrayList = std.ArrayList;
 const Allocator = std.mem.Allocator;
-const hashes_of_zero = @import("./zeros.zig").hashes_of_zero;
 const merkle_cache = @import("./merkle_cache.zig");
 
-// SSZ specification constants
-const BYTES_PER_CHUNK = 32;
-const chunk = [BYTES_PER_CHUNK]u8;
-const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
+const BYTES_PER_CHUNK = lib.BYTES_PER_CHUNK;
+const chunk = lib.chunk;
+const zero_chunk = lib.zero_chunk;
 
 /// Implements the SSZ `List[N]` container.
 pub fn List(T: type, comptime N: usize) type {
@@ -22,21 +20,23 @@ pub fn List(T: type, comptime N: usize) type {
         @compileError("List[bool, N] is not supported. Use Bitlist(" ++ std.fmt.comptimePrint("{}", .{N}) ++ ") instead for boolean lists.");
     }
 
+    // Compile-time check: integer items must be a supported SSZ width.
+    if (comptime @typeInfo(T) == .int) {
+        switch (@typeInfo(T).int.bits) {
+            8, 16, 32, 64, 128, 256 => {},
+            else => @compileError("List item type u" ++ std.fmt.comptimePrint("{d}", .{@typeInfo(T).int.bits}) ++ " is not a valid SSZ integer width; use u8, u16, u32, u64, u128, or u256"),
+        }
+    }
+
     return struct {
         const Self = @This();
-        const Item = T;
+        pub const Item = T;
         const Inner = std.ArrayList(T);
 
         const OFFSET_SIZE = 4;
 
         inner: Inner,
         allocator: Allocator,
-        cache: ?*CacheType = null,
-
-        /// Hasher-agnostic cache type. We use SHA256 as the default since that's the
-        /// standard SSZ hasher, but the cache is only used when hashTreeRoot is called
-        /// with a matching hasher.
-        const CacheType = merkle_cache.MerkleCache(std.crypto.hash.sha2.Sha256);
 
         pub fn sszEncode(self: *const Self, l: *ArrayList(u8), allocator: Allocator) !void {
             try serialize([]const Item, self.constSlice(), l, allocator);
@@ -132,18 +132,16 @@ pub fn List(T: type, comptime N: usize) type {
         }
 
         pub fn deinit(self: *Self) void {
-            if (self.cache) |c| {
-                c.deinit(self.allocator);
-                self.allocator.destroy(c);
-                self.cache = null;
-            }
             self.inner.deinit(self.allocator);
         }
 
         pub fn append(self: *Self, item: Self.Item) error{ Overflow, OutOfMemory }!void {
             if (self.inner.items.len >= N) return error.Overflow;
             try self.inner.append(self.allocator, item);
-            self.invalidateCacheForIndex(self.inner.items.len - 1);
+        }
+
+        pub fn slice(self: *Self) []T {
+            return self.inner.items;
         }
 
         pub fn constSlice(self: *const Self) []const T {
@@ -165,7 +163,6 @@ pub fn List(T: type, comptime N: usize) type {
         pub fn set(self: *Self, i: usize, item: T) error{IndexOutOfBounds}!void {
             if (i >= self.inner.items.len) return error.IndexOutOfBounds;
             self.inner.items[i] = item;
-            self.invalidateCacheForIndex(i);
         }
 
         pub fn len(self: *const Self) usize {
@@ -177,30 +174,7 @@ pub fn List(T: type, comptime N: usize) type {
             return lib.serializedSize(@TypeOf(inner_slice), inner_slice);
         }
 
-        pub fn hashTreeRoot(self: *const Self, Hasher: type, out: *[32]u8, allocator: Allocator) !void {
-            if (Hasher == std.crypto.hash.sha2.Sha256) {
-                // Lazily initialize cache using self.allocator for consistent ownership
-                if (self.cache == null) {
-                    const limit = switch (@typeInfo(Item)) {
-                        .int => blk: {
-                            const bytes_per_item = @sizeOf(Item);
-                            const items_per_chunk = BYTES_PER_CHUNK / bytes_per_item;
-                            break :blk (N + items_per_chunk - 1) / items_per_chunk;
-                        },
-                        else => N,
-                    };
-                    const c = try self.allocator.create(CacheType);
-                    errdefer self.allocator.destroy(c);
-                    c.* = try CacheType.init(self.allocator, limit);
-                    @constCast(&self.cache).* = c;
-                }
-                return self.hashTreeRootCached(out, allocator);
-            }
-
-            return self.hashTreeRootUncached(Hasher, out, allocator);
-        }
-
-        fn hashTreeRootUncached(self: *const Self, Hasher: type, out: *[32]u8, allocator: Allocator) !void {
+        pub fn hashTreeRoot(self: *const Self, Hasher: type, out: *[Hasher.digest_length]u8, allocator: Allocator) !void {
             const items = self.constSlice();
 
             switch (@typeInfo(Item)) {
@@ -209,11 +183,8 @@ pub fn List(T: type, comptime N: usize) type {
                     defer list.deinit(allocator);
                     const chunks = try lib.pack([]const Item, items, &list, allocator);
 
-                    const bytes_per_item = @sizeOf(Item);
-                    const items_per_chunk = BYTES_PER_CHUNK / bytes_per_item;
-                    const chunks_for_max_capacity = (N + items_per_chunk - 1) / items_per_chunk;
                     var tmp: chunk = undefined;
-                    try lib.merkleize(Hasher, chunks, chunks_for_max_capacity, &tmp);
+                    try lib.merkleize(Hasher, chunks, chunkCountLimit(), &tmp);
                     lib.mixInLength2(Hasher, tmp, items.len, out);
                 },
                 else => {
@@ -224,115 +195,50 @@ pub fn List(T: type, comptime N: usize) type {
                         try lib.hashTreeRoot(Hasher, Item, item, &tmp, allocator);
                         try chunks.append(allocator, tmp);
                     }
+                    // Always use N (max capacity) for merkleization, even when empty,
+                    // This ensures proper tree depth according to SSZ specification
                     try lib.merkleize(Hasher, chunks.items, N, &tmp);
                     lib.mixInLength2(Hasher, tmp, items.len, out);
                 },
             }
         }
 
-        /// Free the Merkle cache without freeing the list itself.
-        /// Called by lib.hashTreeRoot to clean up caches on value copies.
-        pub fn deinitCache(self: *Self) void {
-            if (self.cache) |c| {
-                c.deinit(self.allocator);
-                self.allocator.destroy(c);
-                self.cache = null;
-            }
+        // Leaf protocol consumed by TreeHasher (cached hashing)
+
+        /// Number of data chunks currently occupied.
+        pub fn numDataChunks(self: *const Self) usize {
+            const n = self.inner.items.len;
+            return switch (@typeInfo(Item)) {
+                .int => (n * @sizeOf(Item) + BYTES_PER_CHUNK - 1) / BYTES_PER_CHUNK,
+                else => n,
+            };
         }
 
-        fn hashTreeRootCached(self: *const Self, out: *[32]u8, allocator: Allocator) !void {
-            const Sha256 = std.crypto.hash.sha2.Sha256;
-            const items = self.constSlice();
-            const cache = self.cache.?;
+        /// SSZ chunk-count limit (used to derive the merkleization depth).
+        pub fn chunkCountLimit() usize {
+            return switch (@typeInfo(Item)) {
+                .int => (N * @sizeOf(Item) + BYTES_PER_CHUNK - 1) / BYTES_PER_CHUNK,
+                else => N,
+            };
+        }
 
+        /// Derive the bytes of data chunk `idx` (idx < numDataChunks()).
+        pub fn getLeafBytes(self: *const Self, idx: usize, out: *chunk, comptime Hasher: type, allocator: Allocator) !void {
             switch (@typeInfo(Item)) {
                 .int => {
-                    // Pack items into chunks and update dirty leaves
                     const bytes_per_item = @sizeOf(Item);
                     const items_per_chunk = BYTES_PER_CHUNK / bytes_per_item;
-                    const chunks_for_max_capacity = (N + items_per_chunk - 1) / items_per_chunk;
-
-                    if (!cache.initialized) {
-                        // First time: set all leaf chunks
-                        for (0..items.len) |i| {
-                            const chunk_idx = i / items_per_chunk;
-                            const pos_in_chunk = (i % items_per_chunk) * bytes_per_item;
-                            var leaf = cache.nodes[cache.capacity + chunk_idx];
-                            // SSZ requires little-endian encoding
-                            std.mem.writeInt(Item, leaf[pos_in_chunk..][0..bytes_per_item], items[i], .little);
-                            cache.nodes[cache.capacity + chunk_idx] = leaf;
-                        }
-                        cache.markAllDirty();
+                    out.* = zero_chunk;
+                    const start = idx * items_per_chunk;
+                    const end = @min(start + items_per_chunk, self.inner.items.len);
+                    for (start..end) |item_i| {
+                        const pos = (item_i % items_per_chunk) * bytes_per_item;
+                        std.mem.writeInt(Item, out[pos..][0..bytes_per_item], self.inner.items[item_i], .little);
                     }
-                    // For dirty chunks, rebuild from current items
-                    if (cache.dirty_low <= cache.dirty_high) {
-                        const lo = cache.dirty_low;
-                        const hi = @min(cache.dirty_high, if (items.len > 0) (items.len - 1) / items_per_chunk else 0);
-                        for (lo..hi + 1) |chunk_idx| {
-                            var leaf: chunk = zero_chunk;
-                            const start_item = chunk_idx * items_per_chunk;
-                            const end_item = @min(start_item + items_per_chunk, items.len);
-                            for (start_item..end_item) |item_i| {
-                                const pos = (item_i % items_per_chunk) * bytes_per_item;
-                                // SSZ requires little-endian encoding
-                                std.mem.writeInt(Item, leaf[pos..][0..bytes_per_item], items[item_i], .little);
-                            }
-                            cache.nodes[cache.capacity + chunk_idx] = leaf;
-                        }
-                        // Zero out chunks beyond data
-                        for ((if (items.len > 0) (items.len - 1) / items_per_chunk + 1 else 0)..chunks_for_max_capacity) |chunk_idx| {
-                            if (chunk_idx >= cache.dirty_low and chunk_idx <= cache.dirty_high) {
-                                cache.nodes[cache.capacity + chunk_idx] = zero_chunk;
-                            }
-                        }
-                    }
-
-                    const num_data_chunks = if (items.len > 0) (items.len - 1) / items_per_chunk + 1 else 0;
-                    out.* = cache.recomputeWithLength(num_data_chunks, items.len);
                 },
                 else => {
-                    // Composite types: each item is its own chunk (hash tree root of item)
-                    // Composite items may contain pointers to mutable data that
-                    // can change without going through set(), so we must always
-                    // recompute all item hashes. We compare against cached leaves
-                    // to only mark actually-changed nodes dirty for tree rehashing.
-                    var tmp: chunk = undefined;
-                    for (items, 0..) |item, i| {
-                        try lib.hashTreeRoot(Sha256, Item, item, &tmp, allocator);
-                        if (!std.mem.eql(u8, &tmp, &cache.nodes[cache.capacity + i])) {
-                            cache.nodes[cache.capacity + i] = tmp;
-                            cache.markDirty(i);
-                        }
-                    }
-                    // Zero out any previously-occupied slots beyond current length
-                    if (cache.initialized) {
-                        for (items.len..cache.capacity) |i| {
-                            if (!std.mem.eql(u8, &zero_chunk, &cache.nodes[cache.capacity + i])) {
-                                cache.nodes[cache.capacity + i] = zero_chunk;
-                                cache.markDirty(i);
-                            }
-                        }
-                    } else {
-                        cache.markAllDirty();
-                    }
-
-                    out.* = cache.recomputeWithLength(items.len, items.len);
+                    try lib.hashTreeRoot(Hasher, Item, self.inner.items[idx], out, allocator);
                 },
-            }
-        }
-
-        /// Compute the chunk index for a given element index and mark it dirty in the cache.
-        fn invalidateCacheForIndex(self: *Self, element_index: usize) void {
-            if (self.cache) |cache| {
-                const chunk_idx = switch (@typeInfo(Item)) {
-                    .int => blk: {
-                        const bytes_per_item = @sizeOf(Item);
-                        const items_per_chunk = BYTES_PER_CHUNK / bytes_per_item;
-                        break :blk element_index / items_per_chunk;
-                    },
-                    else => element_index,
-                };
-                cache.markDirty(chunk_idx);
             }
         }
 
@@ -360,19 +266,20 @@ pub fn List(T: type, comptime N: usize) type {
     };
 }
 
-/// Implements the SSZ `Bitlist[N]` container
+/// Implements the SSZ `Bitlist[N]` container.
+///
+/// Like `List`, this is the uncached "regular" object; wrap it in
+/// `TreeHasher(Bitlist(N), Hasher)` to add Merkle caching.
 pub fn Bitlist(comptime N: usize) type {
     return struct {
         const Self = @This();
+        pub const Item = bool;
         // stores list without sentinel
         const Inner = std.ArrayList(u8);
 
         inner: Inner,
         allocator: Allocator,
         length: usize,
-        cache: ?*BitCacheType = null,
-
-        const BitCacheType = merkle_cache.MerkleCache(std.crypto.hash.sha2.Sha256);
 
         pub fn sszEncode(self: *const Self, l: *ArrayList(u8), allocator: Allocator) !void {
             if (self.length == 0) {
@@ -460,7 +367,6 @@ pub fn Bitlist(comptime N: usize) type {
             const mask = ~@shlExact(@as(u8, 1), @truncate(i % 8));
             const b = if (bit) @shlExact(@as(u8, 1), @truncate(i % 8)) else 0;
             self.inner.items[i / 8] = @truncate((self.inner.items[i / 8] & mask) | b);
-            if (self.cache) |c| c.markDirty(i / 256);
         }
 
         pub fn append(self: *Self, item: bool) error{ Overflow, OutOfMemory, IndexOutOfBounds }!void {
@@ -477,11 +383,6 @@ pub fn Bitlist(comptime N: usize) type {
         }
 
         pub fn deinit(self: *Self) void {
-            if (self.cache) |c| {
-                c.deinit(self.allocator);
-                self.allocator.destroy(c);
-                self.cache = null;
-            }
             self.inner.deinit(self.allocator);
         }
 
@@ -494,89 +395,55 @@ pub fn Bitlist(comptime N: usize) type {
             return (self.length + 7 + 1) / 8;
         }
 
-        pub fn hashTreeRoot(self: *const Self, Hasher: type, out: *[32]u8, allocator: Allocator) !void {
-            if (Hasher == std.crypto.hash.sha2.Sha256) {
-                // Lazily initialize cache using self.allocator for consistent ownership
-                if (self.cache == null) {
-                    const chunk_count_limit = (N + 255) / 256;
-                    const c = try self.allocator.create(BitCacheType);
-                    errdefer self.allocator.destroy(c);
-                    c.* = try BitCacheType.init(self.allocator, chunk_count_limit);
-                    @constCast(&self.cache).* = c;
-                }
-                return self.hashTreeRootCached(out);
-            }
-            return self.hashTreeRootUncached(Hasher, out, allocator);
-        }
-
-        fn hashTreeRootUncached(self: *const Self, Hasher: type, out: *[32]u8, allocator: Allocator) !void {
+        pub fn hashTreeRoot(self: *const Self, Hasher: type, out: *[Hasher.digest_length]u8, allocator: Allocator) !void {
             const bit_length = self.length;
 
             var bitfield_bytes: ArrayList(u8) = .empty;
             defer bitfield_bytes.deinit(allocator);
 
             if (bit_length > 0) {
+                // Get the internal bit data since we don't store delimiter
                 const sl = self.inner.items;
                 try bitfield_bytes.appendSlice(allocator, sl[0..sl.len]);
 
+                // Remove trailing zeros but keep at least one byte
+                // This avoids the wasteful pattern of removing all zeros and then adding back a chunk
                 while (bitfield_bytes.items.len > 1 and bitfield_bytes.items[bitfield_bytes.items.len - 1] == 0) {
                     _ = bitfield_bytes.pop();
                 }
             }
 
+            // Pack bits into chunks (pad to chunk boundary)
             const padding_size = (BYTES_PER_CHUNK - bitfield_bytes.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
             _ = try bitfield_bytes.appendSlice(allocator, zero_chunk[0..padding_size]);
 
             const chunks = std.mem.bytesAsSlice(chunk, bitfield_bytes.items);
             var tmp: chunk = undefined;
 
-            const chunk_count_limit = (N + 255) / 256;
-            try lib.merkleize(Hasher, chunks, chunk_count_limit, &tmp);
+            try lib.merkleize(Hasher, chunks, chunkCountLimit(), &tmp);
             lib.mixInLength2(Hasher, tmp, bit_length, out);
         }
 
-        fn hashTreeRootCached(self: *const Self, out: *[32]u8) void {
-            const cache = self.cache.?;
-            const bit_length = self.length;
+        // Leaf protocol consumed by TreeHasher (cached hashing)
 
-            // Update dirty leaf chunks from current bit data
-            if (!cache.initialized) {
-                // Set all leaf chunks from bit data
-                const sl = self.inner.items;
-                const num_data_chunks = if (sl.len > 0) (sl.len - 1) / BYTES_PER_CHUNK + 1 else 0;
-                for (0..num_data_chunks) |ci| {
-                    var leaf: chunk = zero_chunk;
-                    const start = ci * BYTES_PER_CHUNK;
-                    const end = @min(start + BYTES_PER_CHUNK, sl.len);
-                    @memcpy(leaf[0 .. end - start], sl[start..end]);
-                    cache.nodes[cache.capacity + ci] = leaf;
-                }
-                cache.markAllDirty();
-            } else if (cache.dirty_low <= cache.dirty_high) {
-                const sl = self.inner.items;
-                const hi = @min(cache.dirty_high, if (sl.len > 0) (sl.len - 1) / BYTES_PER_CHUNK else 0);
-                for (cache.dirty_low..hi + 1) |ci| {
-                    var leaf: chunk = zero_chunk;
-                    const start = ci * BYTES_PER_CHUNK;
-                    const end = @min(start + BYTES_PER_CHUNK, sl.len);
-                    if (start < sl.len) {
-                        @memcpy(leaf[0 .. end - start], sl[start..end]);
-                    }
-                    cache.nodes[cache.capacity + ci] = leaf;
-                }
-            }
-
-            const num_data_chunks = if (self.inner.items.len > 0) (self.inner.items.len - 1) / BYTES_PER_CHUNK + 1 else 0;
-            out.* = cache.recomputeWithLength(num_data_chunks, bit_length);
+        pub fn numDataChunks(self: *const Self) usize {
+            const n = self.inner.items.len; // bytes
+            return (n + BYTES_PER_CHUNK - 1) / BYTES_PER_CHUNK;
         }
 
-        /// Free the Merkle cache without freeing the bitlist itself.
-        /// Called by lib.hashTreeRoot to clean up caches on value copies.
-        pub fn deinitCache(self: *Self) void {
-            if (self.cache) |c| {
-                c.deinit(self.allocator);
-                self.allocator.destroy(c);
-                self.cache = null;
+        pub fn chunkCountLimit() usize {
+            return (N + 255) / 256;
+        }
+
+        pub fn getLeafBytes(self: *const Self, idx: usize, out: *chunk, comptime Hasher: type, allocator: Allocator) !void {
+            _ = Hasher;
+            _ = allocator;
+            out.* = zero_chunk;
+            const sl = self.inner.items;
+            const start = idx * BYTES_PER_CHUNK;
+            if (start < sl.len) {
+                const end = @min(start + BYTES_PER_CHUNK, sl.len);
+                @memcpy(out[0 .. end - start], sl[start..end]);
             }
         }
 
@@ -611,6 +478,83 @@ pub fn Bitlist(comptime N: usize) type {
             if (num_of_bits > N) {
                 return error.BitlistTooManyBits;
             }
+        }
+    };
+}
+
+/// Hasher-agnostic Merkle-caching wrapper around a regular List/Bitlist.
+///
+/// Caching is opt-in: use the raw `Inner` for no cache,
+/// or `TreeHasher(Inner, Hasher)` for a persistent cache.
+///
+/// The cache is owned via a heap pointer that survives by-value copies of the
+/// wrapper (as happens when a containing struct is hashed), so a cached field
+/// keeps its tree across calls. Leaves are refreshed content-addressed on every
+/// call (re-derived from the backing store and compared), so the root never goes
+/// stale even if the backing store is mutated directly.
+pub fn TreeHasher(comptime Inner: type, comptime Hasher: type) type {
+    return struct {
+        const Self = @This();
+        const Cache = merkle_cache.MerkleCache(Hasher);
+        const target_depth = merkle_cache.targetDepth(Inner.chunkCountLimit());
+
+        inner: Inner,
+        cache: *Cache,
+        allocator: Allocator,
+
+        pub fn init(allocator: Allocator) !Self {
+            const c = try allocator.create(Cache);
+            errdefer allocator.destroy(c);
+            c.* = Cache.init();
+            return .{ .inner = try Inner.init(allocator), .cache = c, .allocator = allocator };
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.cache.deinit(self.allocator);
+            self.allocator.destroy(self.cache);
+            self.inner.deinit();
+        }
+
+        pub fn hashTreeRoot(self: *const Self, H: type, out: *[H.digest_length]u8, allocator: Allocator) !void {
+            // The cache is keyed to `Hasher`; a different hasher falls back to
+            // the regular uncached object.
+            if (H == Hasher) return self.hashTreeRootCached(out, allocator);
+            return self.inner.hashTreeRoot(H, out, allocator);
+        }
+
+        fn hashTreeRootCached(self: *const Self, out: *[Hasher.digest_length]u8, allocator: Allocator) !void {
+            const cache = self.cache;
+            const data_chunks = self.inner.numDataChunks();
+            try cache.ensureCapacity(self.allocator, data_chunks);
+
+            // Content-addressed leaf refresh: re-derive each leaf from the
+            // backing store and mark dirty only those that actually changed.
+            var leaf: chunk = undefined;
+            for (0..cache.capacity) |i| {
+                if (i < data_chunks) {
+                    try self.inner.getLeafBytes(i, &leaf, Hasher, allocator);
+                } else {
+                    leaf = zero_chunk;
+                }
+                if (!std.mem.eql(u8, &leaf, cache.leafPtr(i))) {
+                    cache.leafPtr(i).* = leaf;
+                    cache.markDirty(i);
+                }
+            }
+
+            out.* = cache.recomputeWithLength(self.inner.len(), target_depth);
+        }
+
+        pub fn len(self: *const Self) usize {
+            return self.inner.len();
+        }
+
+        pub fn set(self: *Self, i: usize, item: Inner.Item) !void {
+            return self.inner.set(i, item);
+        }
+
+        pub fn append(self: *Self, item: Inner.Item) !void {
+            return self.inner.append(item);
         }
     };
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -275,9 +275,6 @@ pub fn List(T: type, comptime N: usize) type {
 }
 
 /// Implements the SSZ `Bitlist[N]` container.
-///
-/// Like `List`, this is the uncached "regular" object; wrap it in
-/// `TreeHasher(Bitlist(N), Hasher)` to add Merkle caching.
 pub fn Bitlist(comptime N: usize) type {
     return struct {
         const Self = @This();


### PR DESCRIPTION
Adds caching in hashing path for List and BitList
- Supports caching only when hashing with Sha256
- init API doesn't take in Hasher as an input so CacheType cannot be Hasher agnostic without API changes
- Can support multiple Hasher in CacheType either by updating init API or by storing a list of CacheType which can be appended based on the Hasher call in hashTreeRoot